### PR TITLE
feat: pipeline orchestrator — full OpenClaw plugin implementation

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# RailClaw Pipeline — pre-commit hook
+set -euo pipefail
+
+PASS=true
+
+echo "🔍 Running TypeScript type check..."
+if ! npx tsc --noEmit 2>&1; then
+  echo "❌ TypeScript type check failed"
+  PASS=false
+fi
+
+echo "🔍 Running Prettier check..."
+if ! npx prettier --check 'src/**/*.ts' 2>&1; then
+  echo "❌ Prettier check failed — run 'npx prettier --write src/**/*.ts'"
+  PASS=false
+fi
+
+echo "🔍 Running ESLint..."
+if ! npx eslint 'src/**/*.ts' 2>&1; then
+  echo "❌ ESLint failed"
+  PASS=false
+fi
+
+echo "🐍 Running Python tests..."
+if ! (cd python && python -m pytest tests/ 2>&1); then
+  echo "❌ Python tests failed"
+  PASS=false
+fi
+
+echo "🐍 Running ruff check..."
+if ! (cd python && ruff check src/ 2>&1); then
+  echo "❌ Ruff linting failed"
+  PASS=false
+fi
+
+if [ "$PASS" = false ]; then
+  echo ""
+  echo "⛔ Pre-commit checks failed. Fix the above errors and try again."
+  exit 1
+fi
+
+echo "✅ All pre-commit checks passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# RailClaw Pipeline — pre-push hook
+set -euo pipefail
+
+PASS=true
+
+echo "🚀 Running full test suites..."
+
+echo "📦 npm test..."
+if ! npm test 2>&1; then
+  echo "❌ npm test failed"
+  PASS=false
+fi
+
+echo "📦 python -m pytest..."
+if ! (cd python && python -m pytest tests/ -v 2>&1); then
+  echo "❌ Python tests failed"
+  PASS=false
+fi
+
+# Check for TODO/FIXME in staged files — warn only, never block
+echo "🔍 Checking for TODO/FIXME comments in staged files..."
+STAGED_FILES=$(git diff --cached --name-only 2>/dev/null || true)
+if [ -n "$STAGED_FILES" ]; then
+  TODOS=$(echo "$STAGED_FILES" | xargs grep -n 'TODO\|FIXME' 2>/dev/null || true)
+  if [ -n "$TODOS" ]; then
+    echo "⚠️  Warning: TODO/FIXME found in staged files:"
+    echo "$TODOS"
+    echo "(not blocking push, but consider resolving these)"
+  fi
+fi
+
+if [ "$PASS" = false ]; then
+  echo ""
+  echo "⛔ Pre-push tests failed. Push aborted."
+  exit 1
+fi
+
+echo "✅ All pre-push checks passed."

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,59 @@
-_refs/
+# ── Dependencies ──────────────────────────────────────────────
 node_modules/
+python/.venv/
+python/venv/
+
+# ── Build output ──────────────────────────────────────────────
+dist/
+build/
+*.tsbuildinfo
+*.egg-info/
+
+# ── Python ────────────────────────────────────────────────────
 __pycache__/
 *.pyc
 *.pyo
 *.pyd
 .Python
-dist/
-build/
-*.egg-info/
 .pytest_cache/
 .mypy_cache/
+.coverage
+htmlcov/
+*.so
+
+# ── Node ──────────────────────────────────────────────────────
+.npm
+.eslintcache
+*.tsbuildinfo
+
+# ── IDEs & editors ───────────────────────────────────────────
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+*.sublime-project
+*.sublime-workspace
+
+# ── OS generated ──────────────────────────────────────────────
+.DS_Store
+.DS_Store?
+Thumbs.db
+ehthumbs.db
+
+# ── Plugin runtime state ──────────────────────────────────────
 .state/
 state.json
 events.jsonl
+logs/
+
+# ── Misc ──────────────────────────────────────────────────────
+*.tmp
+*.bak
+*.log
+.env
+.env.local
 .python-version
+
+# ── Reference copies (not part of repo) ───────────────────────
+_refs/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,149 @@
+# railclaw-pipeline
+
+OpenClaw plugin for automated coding factory pipeline orchestration. Plans, implements, reviews, merges, deploys, and QA-tests code changes from GitHub issues.
+
+## Installation
+
+```bash
+openclaw plugins install chrisufo/railclaw-pipeline
+```
+
+The postinstall script runs `pip install -e ./python` automatically.
+
+## Configuration
+
+Add to your `openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "railclaw-pipeline": {
+        "enabled": true,
+        "config": {
+          "repoPath": "/path/to/target/repo",
+          "factoryPath": "/path/to/factory",
+          "agents": {
+            "blueprint": { "model": "openai/gpt-5.4", "timeout": 600 },
+            "wrench": { "model": "zai/glm-5-turbo", "timeout": 1200 },
+            "scope": { "model": "minimax/MiniMax-M2.7", "timeout": 600 },
+            "beaker": { "model": "openai/gpt-5.4-mini", "timeout": 600 },
+            "wrenchSr": { "model": "gemini/gemini-3.1-pro-preview", "timeout": 1200 }
+          },
+          "escalation": {
+            "wrenchSrAfterRound": 3,
+            "chrisAfterRound": 5
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Config Options
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `repoPath` | `.` | Target repository path |
+| `factoryPath` | `factory` | Factory directory with prompts and state |
+| `pythonCommand` | `railclaw-pipeline` | Python CLI command |
+| `stateDir` | `.pipeline-state` | State file directory |
+| `eventsDir` | `.pipeline-events` | Event log directory |
+| `agents.*` | — | Per-agent model and timeout |
+| `timing.geminiPollInterval` | `60` | Seconds between Gemini review polls |
+| `timing.approvalTimeout` | `86400` | Max seconds to wait for human approval |
+| `pm2.processName` | `railclaw-mc` | PM2 process name for deploy |
+| `escalation.wrenchSrAfterRound` | `3` | Switch to Wrench Sr after N fix rounds |
+| `escalation.chrisAfterRound` | `5` | Escalate to Chris after N fix rounds |
+
+## Usage
+
+The plugin registers a `pipeline_run` tool with these actions:
+
+- **`run`** — Start a new pipeline for an issue or milestone
+- **`status`** — Check current pipeline state
+- **`resume`** — Resume an interrupted pipeline
+- **`abort`** — Cancel the active pipeline
+
+### Hotfix Mode
+
+Set `hotfix: true` to run post-hoc review on a direct-to-main hotfix. Bypasses stages 1-2.5, runs Scope review on the diff, creates a follow-up PR if findings exist.
+
+## Architecture
+
+```
+railclaw-pipeline/
+  src/                          # TypeScript plugin layer (~50-100 lines logic)
+    index.ts                    # definePluginEntry — registration + wiring
+    tool.ts                     # api.registerTool() + TypeBox parameter schema
+    config.ts                   # Plugin config normalization
+    python-bridge.ts            # Subprocess wrapper around Python CLI
+    store.ts                    # Runtime store for active run metadata
+    hooks.ts                    # Lifecycle hooks (startup/shutdown)
+  python/
+    src/railclaw_pipeline/
+      cli.py                    # Click CLI: run, status, resume, abort
+      config.py                 # Settings from env/CLI/plugin config
+      pipeline.py               # Stage runner orchestrator
+      state/                    # Pydantic models + atomic JSON persistence
+      runner/                   # Agent subprocess execution
+      stages/                   # Pipeline stage implementations
+      github/                   # Git/gh CLI wrappers
+      prompts/                  # Jinja2 template loader (sandboxed)
+      events/                   # JSON lines event emitter
+      milestone/                # Multi-issue milestone mode
+```
+
+### Pipeline Stages
+
+| Stage | Agent | Description |
+|-------|-------|-------------|
+| 0 — Preflight | — | Environment checks |
+| 1 — Blueprint | Blueprint | Planning |
+| 2 — Wrench | Wrench | Implementation |
+| 2.5 — PR | — | PR creation |
+| 3 — Audit | Scope | Completeness audit |
+| 3.5 — Audit Fix | Wrench | Fix audit findings |
+| 4 — Review | Scope | Code review |
+| 5 — Fix Loop | Wrench/Wrench Sr | Fix review findings (max 5 rounds) |
+| Cycle 2 | Gemini | External review loop |
+| 7 — Docs | Quill | Documentation (opt-in) |
+| 8 — Approval | — | Human approval gate |
+| 8c — Merge | — | Squash merge + branch delete |
+| 9 — Deploy | — | PM2 restart + health check |
+| 10 — QA | Beaker | QA sweep |
+| 11 — Hotfix | Scope/Wrench | Post-hoc hotfix review |
+| 12 — Lessons | — | Lessons learned generation |
+
+### Security
+
+- `shell=False` on all subprocess calls
+- Jinja2 sandboxed templates (SSTI protection)
+- Branch name sanitization before use in commands/paths
+- No secrets in state files or event logs
+
+## Development
+
+```bash
+npm install                    # Install JS deps + Python package
+npm run build                  # TypeScript compile
+npm run test                   # JS tests
+npm run test:py                # Python tests
+npm run lint                   # ESLint
+npm run lint:py                # Ruff
+npm run typecheck              # tsc --noEmit
+```
+
+### Python Dev
+
+```bash
+cd python
+pip install -e ".[dev]"
+pytest tests/ -v
+ruff check src/
+```
+
+## License
+
+MIT

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,23 @@
+import eslint from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+
+export default [
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": eslint,
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/explicit-function-return-type": "warn",
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
+];

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,0 +1,19 @@
+{
+  "id": "railclaw-pipeline",
+  "name": "RailClaw Pipeline Orchestrator",
+  "description": "Automated coding factory pipeline: planning → implementation → review → merge → deploy → QA",
+  "version": "0.1.0",
+  "author": "Chris Harrison",
+  "license": "MIT",
+  "repository": "https://github.com/ChrisUFO/railclaw-pipeline",
+  "main": "dist/index.js",
+  "extensions": ["./dist/index.js"],
+  "compat": {
+    "pluginApi": ">=2026.3.24-beta.2",
+    "minGatewayVersion": "2026.3.24-beta.2"
+  },
+  "build": {
+    "openclawVersion": "2026.3.24-beta.2",
+    "pluginSdkVersion": "2026.3.24-beta.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@chrisufo/railclaw-pipeline",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "OpenClaw plugin for automated coding factory pipeline orchestration",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "prepare": "git config core.hooksPath .githooks && npm run build",
+    "postinstall": "bash scripts/postinstall.sh",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:watch": "npm run test -- --watch",
+    "lint": "eslint src --ext .ts",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write src/**/*.ts",
+    "lint:py": "cd python && ruff check src/",
+    "test:py": "cd python && python -m pytest tests/ -v"
+  },
+  "keywords": [
+    "openclaw",
+    "plugin",
+    "pipeline",
+    "orchestration",
+    "automation",
+    "coding-factory"
+  ],
+  "author": "Chris Harrison",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ChrisUFO/railclaw-pipeline.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ChrisUFO/railclaw-pipeline/issues"
+  },
+  "homepage": "https://github.com/ChrisUFO/railclaw-pipeline#readme",
+  "dependencies": {
+    "@sinclair/typebox": "^0.32.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@types/node": "^22.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.3.0",
+    "prettier": "^3.2.0",
+    "eslint": "^9.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "openclaw": {
+    "extensions": [
+      "./dist/index.js"
+    ],
+    "compat": {
+      "pluginApi": ">=2026.3.24-beta.2",
+      "minGatewayVersion": "2026.3.24-beta.2"
+    },
+    "build": {
+      "openclawVersion": "2026.3.24-beta.2",
+      "pluginSdkVersion": "2026.3.24-beta.2"
+    }
+  }
+}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,66 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "railclaw-pipeline"
+version = "0.1.0"
+description = "Pipeline orchestrator for automated coding factory"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "MIT"}
+authors = [
+    {name = "Chris Harrison", email = "chris@example.com"}
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+dependencies = [
+    "pydantic>=2.0",
+    "click>=8.1",
+    "jinja2>=3.1",
+    "rich>=13.0",
+    "tenacity>=8.2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "pytest-cov>=4.0",
+    "mypy>=1.0",
+    "ruff>=0.3.0",
+]
+
+[project.scripts]
+railclaw-pipeline = "railclaw_pipeline.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "UP", "B", "SIM"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,5 @@
+pydantic>=2.0
+click>=8.1
+jinja2>=3.1
+rich>=13.0
+tenacity>=8.2

--- a/python/src/railclaw_pipeline/__init__.py
+++ b/python/src/railclaw_pipeline/__init__.py
@@ -1,0 +1,3 @@
+"""RailClaw Pipeline Orchestrator - Automated coding factory pipeline."""
+
+__version__ = "0.1.0"

--- a/python/src/railclaw_pipeline/cli.py
+++ b/python/src/railclaw_pipeline/cli.py
@@ -1,5 +1,6 @@
 """CLI interface for pipeline orchestrator."""
 
+import asyncio
 import json
 import os
 from datetime import datetime, timezone
@@ -83,15 +84,43 @@ def run(issue: int | None, milestone: str | None, hotfix: bool, force_stage: str
     )
     
     save_state(state, state_path)
-    
+
+    from railclaw_pipeline.config import PipelineConfig
+    from railclaw_pipeline.events.emitter import EventEmitter
+    from railclaw_pipeline.pipeline import run_pipeline
+
+    config = PipelineConfig({
+        "repoPath": os.environ.get("RAILCLAW_REPO_PATH", "."),
+        "factoryPath": os.environ.get("RAILCLAW_FACTORY_PATH", "factory"),
+    })
+    emitter = EventEmitter(config.events_path)
+
+    try:
+        if hotfix:
+            asyncio.run(run_pipeline(state, config, emitter, hotfix=True))
+        else:
+            asyncio.run(run_pipeline(state, config, emitter))
+
+        state = load_state(state_path)
+    except Exception as exc:
+        state = load_state(state_path) or state
+        state.status = PipelineStatus.FAILED
+        state.error = {"message": str(exc)}
+        save_state(state, state_path)
+    finally:
+        emitter.close()
+
     output_result({
-        "ok": True,
+        "ok": state.status == PipelineStatus.COMPLETED,
         "action": "run",
         "stage": state.stage.value,
         "status": state.status.value,
         "issueNumber": state.issue_number,
-        "message": "Pipeline started",
+        "prNumber": state.pr_number,
+        "branch": state.branch,
+        "message": f"Pipeline {state.status.value}" + (f": {state.error['message']}" if state.error else ""),
         "statePath": str(state_path),
+        "error": state.error.get("message") if state.error else None,
     })
 
 

--- a/python/src/railclaw_pipeline/cli.py
+++ b/python/src/railclaw_pipeline/cli.py
@@ -103,7 +103,10 @@ def run(issue: int | None, milestone: str | None, hotfix: bool, force_stage: str
 
         state = load_state(state_path)
     except Exception as exc:
-        state = load_state(state_path) or state
+        try:
+            state = load_state(state_path)
+        except FileNotFoundError:
+            pass
         state.status = PipelineStatus.FAILED
         state.error = {"message": str(exc)}
         save_state(state, state_path)
@@ -128,9 +131,9 @@ def run(issue: int | None, milestone: str | None, hotfix: bool, force_stage: str
 def status() -> None:
     """Show current pipeline status."""
     state_path = get_state_path()
-    state = load_state(state_path)
-    
-    if not state:
+    try:
+        state = load_state(state_path)
+    except FileNotFoundError:
         output_result({
             "ok": True,
             "action": "status",
@@ -156,9 +159,9 @@ def status() -> None:
 def resume(force_stage: str | None) -> None:
     """Resume a paused or interrupted pipeline."""
     state_path = get_state_path()
-    state = load_state(state_path)
-    
-    if not state:
+    try:
+        state = load_state(state_path)
+    except FileNotFoundError:
         output_result({
             "ok": False,
             "action": "resume",
@@ -189,9 +192,9 @@ def resume(force_stage: str | None) -> None:
 def abort() -> None:
     """Abort the current pipeline run."""
     state_path = get_state_path()
-    state = load_state(state_path)
-    
-    if not state:
+    try:
+        state = load_state(state_path)
+    except FileNotFoundError:
         output_result({
             "ok": False,
             "action": "abort",

--- a/python/src/railclaw_pipeline/cli.py
+++ b/python/src/railclaw_pipeline/cli.py
@@ -1,0 +1,193 @@
+"""CLI interface for pipeline orchestrator."""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import click
+from railclaw_pipeline.state.models import (
+    CycleState,
+    PipelineStage,
+    PipelineState,
+    PipelineStatus,
+    Timestamps,
+)
+from railclaw_pipeline.state.persistence import load_state, save_state
+
+
+def get_state_path() -> Path:
+    """Get state file path from environment or default."""
+    state_dir = os.environ.get("RAILCLAW_STATE_DIR", ".pipeline-state")
+    factory_path = os.environ.get("RAILCLAW_FACTORY_PATH", "factory")
+    return Path(factory_path) / state_dir / "state.json"
+
+
+def get_events_path() -> Path:
+    """Get events file path from environment or default."""
+    events_dir = os.environ.get("RAILCLAW_EVENTS_DIR", ".pipeline-events")
+    factory_path = os.environ.get("RAILCLAW_FACTORY_PATH", "factory")
+    return Path(factory_path) / events_dir / "events.jsonl"
+
+
+def output_result(data: dict[str, Any]) -> None:
+    """Output JSON result to stdout for TypeScript bridge."""
+    print(json.dumps(data, default=str))
+
+
+@click.group()
+def main() -> None:
+    """RailClaw Pipeline Orchestrator CLI."""
+    pass
+
+
+@main.command()
+@click.option("--issue", type=int, help="Issue number to process")
+@click.option("--milestone", type=str, help="Milestone label for multi-issue mode")
+@click.option("--hotfix", is_flag=True, help="Run in hotfix mode")
+@click.option("--force-stage", type=str, help="Force start at specific stage")
+def run(issue: int | None, milestone: str | None, hotfix: bool, force_stage: str | None) -> None:
+    """Start a new pipeline run."""
+    if not issue and not milestone:
+        output_result({
+            "ok": False,
+            "action": "run",
+            "error": "issue or milestone is required"
+        })
+        return
+    
+    state_path = get_state_path()
+    
+    if state_path.exists():
+        output_result({
+            "ok": False,
+            "action": "run",
+            "error": "Pipeline already running. Use 'resume' or 'abort' first."
+        })
+        return
+    
+    now = datetime.now(timezone.utc)
+    state = PipelineState(
+        issue_number=issue or 0,
+        milestone_mode=milestone is not None,
+        milestone_label=milestone,
+        stage=PipelineStage.STAGE0_PREFLIGHT if not force_stage else PipelineStage(force_stage),
+        status=PipelineStatus.RUNNING,
+        timestamps=Timestamps(
+            started=now,
+            stage_entered=now,
+            last_updated=now,
+        ),
+        cycle=CycleState(),
+    )
+    
+    save_state(state, state_path)
+    
+    output_result({
+        "ok": True,
+        "action": "run",
+        "stage": state.stage.value,
+        "status": state.status.value,
+        "issueNumber": state.issue_number,
+        "message": "Pipeline started",
+        "statePath": str(state_path),
+    })
+
+
+@main.command()
+def status() -> None:
+    """Show current pipeline status."""
+    state_path = get_state_path()
+    state = load_state(state_path)
+    
+    if not state:
+        output_result({
+            "ok": True,
+            "action": "status",
+            "message": "No active pipeline",
+        })
+        return
+    
+    output_result({
+        "ok": True,
+        "action": "status",
+        "stage": state.stage.value,
+        "status": state.status.value,
+        "issueNumber": state.issue_number,
+        "prNumber": state.pr_number,
+        "branch": state.branch,
+        "message": f"Pipeline {state.status.value} at {state.stage.value}",
+        "statePath": str(state_path),
+    })
+
+
+@main.command()
+@click.option("--force-stage", type=str, help="Force resume at specific stage")
+def resume(force_stage: str | None) -> None:
+    """Resume a paused or interrupted pipeline."""
+    state_path = get_state_path()
+    state = load_state(state_path)
+    
+    if not state:
+        output_result({
+            "ok": False,
+            "action": "resume",
+            "error": "No pipeline state found"
+        })
+        return
+    
+    if force_stage:
+        state.stage = PipelineStage(force_stage)
+    
+    state.status = PipelineStatus.RUNNING
+    state.timestamps.last_updated = datetime.now(timezone.utc) if state.timestamps else None
+    
+    save_state(state, state_path)
+    
+    output_result({
+        "ok": True,
+        "action": "resume",
+        "stage": state.stage.value,
+        "status": state.status.value,
+        "issueNumber": state.issue_number,
+        "message": f"Pipeline resumed at {state.stage.value}",
+        "statePath": str(state_path),
+    })
+
+
+@main.command()
+def abort() -> None:
+    """Abort the current pipeline run."""
+    state_path = get_state_path()
+    state = load_state(state_path)
+    
+    if not state:
+        output_result({
+            "ok": False,
+            "action": "abort",
+            "error": "No pipeline state found"
+        })
+        return
+    
+    state.status = PipelineStatus.FAILED
+    state.error = {"message": "Aborted by user"}
+    
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+    
+    save_state(state, state_path)
+    
+    output_result({
+        "ok": True,
+        "action": "abort",
+        "stage": state.stage.value,
+        "status": state.status.value,
+        "issueNumber": state.issue_number,
+        "message": "Pipeline aborted",
+        "statePath": str(state_path),
+    })
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/railclaw_pipeline/config.py
+++ b/python/src/railclaw_pipeline/config.py
@@ -1,0 +1,62 @@
+"""Pipeline configuration from environment and plugin config."""
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+class PipelineConfig:
+    """Pipeline configuration loaded from environment and plugin config."""
+    
+    def __init__(self, config_dict: dict[str, Any] | None = None) -> None:
+        config_dict = config_dict or {}
+        
+        self.repo_path = Path(
+            config_dict.get("repoPath") or
+            os.environ.get("RAILCLAW_REPO_PATH", ".")
+        )
+        
+        self.factory_path = Path(
+            config_dict.get("factoryPath") or
+            os.environ.get("RAILCLAW_FACTORY_PATH", "factory")
+        )
+        
+        self.state_dir = config_dict.get("stateDir") or ".pipeline-state"
+        self.events_dir = config_dict.get("eventsDir") or ".pipeline-events"
+        
+        self.state_path = self.factory_path / self.state_dir / "state.json"
+        self.events_path = self.factory_path / self.events_dir / "events.jsonl"
+        
+        self.agents = config_dict.get("agents", {
+            "blueprint": {"model": "openai/gpt-5.4", "timeout": 600},
+            "wrench": {"model": "zai/glm-5-turbo", "timeout": 1200},
+            "scope": {"model": "minimax/MiniMax-M2.7", "timeout": 600},
+            "beaker": {"model": "openai/gpt-5.4-mini", "timeout": 600},
+            "wrenchSr": {"model": "gemini/gemini-3.1-pro-preview", "timeout": 1200},
+        })
+        
+        self.timing = config_dict.get("timing", {
+            "geminiPollInterval": 60,
+            "approvalTimeout": 86400,
+            "healthCheckTimeout": 30,
+        })
+        
+        self.pm2 = config_dict.get("pm2", {
+            "processName": "railclaw-mc",
+            "ecosystemPath": "ecosystem.config.cjs",
+        })
+        
+        self.escalation = config_dict.get("escalation", {
+            "wrenchSrAfterRound": 3,
+            "chrisAfterRound": 5,
+        })
+    
+    def get_agent_timeout(self, agent: str) -> int:
+        """Get timeout for specific agent."""
+        agent_config = self.agents.get(agent, {})
+        return agent_config.get("timeout", 600)
+    
+    def get_agent_model(self, agent: str) -> str:
+        """Get model for specific agent."""
+        agent_config = self.agents.get(agent, {})
+        return agent_config.get("model", "")

--- a/python/src/railclaw_pipeline/events/__init__.py
+++ b/python/src/railclaw_pipeline/events/__init__.py
@@ -1,0 +1,1 @@
+"""Event emission helpers."""

--- a/python/src/railclaw_pipeline/events/console.py
+++ b/python/src/railclaw_pipeline/events/console.py
@@ -1,0 +1,65 @@
+"""Rich console output for pipeline progress."""
+
+from datetime import datetime
+from typing import Any
+
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from rich.table import Table
+
+from railclaw_pipeline.state.models import PipelineStage, PipelineState
+
+
+class ConsoleReporter:
+    """Rich-based console output for pipeline progress."""
+    
+    def __init__(self) -> None:
+        self.console = Console()
+        self._progress: Progress | None = None
+    
+    def stage_start(self, stage: PipelineStage, issue: int) -> None:
+        """Print stage start message."""
+        self.console.print(f"\n[cyan]▶ Stage:[/cyan] {stage.value}")
+        self.console.print(f"[dim]Issue #{issue}[/dim]")
+    
+    def stage_end(self, stage: PipelineStage, success: bool, duration: float) -> None:
+        """Print stage end message."""
+        status = "[green]✓[/green]" if success else "[red]✗[/red]"
+        duration_str = f"{duration:.1f}s"
+        self.console.print(f"{status} {stage.value} completed in {duration_str}")
+    
+    def agent_start(self, agent: str) -> None:
+        """Print agent start message."""
+        self.console.print(f"[yellow]→ Agent:[/yellow] {agent}")
+    
+    def agent_end(self, agent: str, success: bool, duration: float) -> None:
+        """Print agent end message."""
+        status = "[green]✓[/green]" if success else "[red]✗[/red]"
+        duration_str = f"{duration:.1f}s"
+        self.console.print(f"{status} {agent} finished in {duration_str}")
+    
+    def error(self, message: str) -> None:
+        """Print error message."""
+        self.console.print(f"[red]ERROR:[/red] {message}")
+    
+    def info(self, message: str) -> None:
+        """Print info message."""
+        self.console.print(f"[blue]INFO:[/blue] {message}")
+    
+    def print_state(self, state: PipelineState) -> None:
+        """Print current pipeline state."""
+        table = Table(title=f"Pipeline State - Issue #{state.issue_number}")
+        table.add_column("Field", style="cyan")
+        table.add_column("Value", style="green")
+        
+        table.add_row("Stage", state.stage.value)
+        table.add_row("Status", state.status.value)
+        if state.pr_number:
+            table.add_row("PR", f"#{state.pr_number}")
+        if state.branch:
+            table.add_row("Branch", state.branch)
+        if state.timestamps:
+            table.add_row("Started", state.timestamps.started.isoformat())
+            table.add_row("Last Updated", state.timestamps.last_updated.isoformat())
+        
+        self.console.print(table)

--- a/python/src/railclaw_pipeline/events/emitter.py
+++ b/python/src/railclaw_pipeline/events/emitter.py
@@ -1,0 +1,48 @@
+"""JSON lines event emitter with buffered writes."""
+
+import json
+import threading
+from collections import deque
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class EventEmitter:
+    """Buffers events in memory, flushes to disk periodically."""
+    
+    def __init__(self, events_path: Path, flush_interval: float = 30.0):
+        self.events_path = events_path
+        self.flush_interval = flush_interval
+        self._buffer: deque[str] = deque()
+        self._lock = threading.Lock()
+        self.events_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    def emit(self, event_type: str, **kwargs: Any) -> None:
+        """Emit an event to the buffer."""
+        event = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "type": event_type,
+            **kwargs
+        }
+        line = json.dumps(event, default=str)
+        
+        with self._lock:
+            self._buffer.append(line)
+    
+    def flush_now(self) -> None:
+        """Flush immediately - called on stage transitions and shutdown."""
+        with self._lock:
+            if not self._buffer:
+                return
+            lines = list(self._buffer)
+            self._buffer.clear()
+        
+        with open(self.events_path, "a") as f:
+            for line in lines:
+                f.write(line + "\n")
+            f.flush()
+    
+    def close(self) -> None:
+        """Flush and close."""
+        self.flush_now()

--- a/python/src/railclaw_pipeline/github/__init__.py
+++ b/python/src/railclaw_pipeline/github/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub and Git operation wrappers."""

--- a/python/src/railclaw_pipeline/github/board.py
+++ b/python/src/railclaw_pipeline/github/board.py
@@ -1,0 +1,101 @@
+"""Board JSON helpers — read/update factory/board.json."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+class BoardError(Exception):
+    """Raised when board operations fail."""
+    pass
+
+
+def load_board(factory_path: Path) -> dict[str, Any]:
+    """Load board.json from factory directory.
+
+    Returns empty dict if file doesn't exist.
+    """
+    board_path = factory_path / "board.json"
+    if not board_path.exists():
+        return {}
+    try:
+        data = json.loads(board_path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError) as exc:
+        raise BoardError(f"Failed to load board.json: {exc}") from exc
+
+
+def save_board(factory_path: Path, board: dict[str, Any]) -> None:
+    """Atomically save board.json."""
+    board_path = factory_path / "board.json"
+    board_path.parent.mkdir(parents=True, exist_ok=True)
+    data = json.dumps(board, indent=2, ensure_ascii=False)
+
+    import tempfile
+    import os
+    fd, tmp_path = tempfile.mkstemp(dir=str(board_path.parent), suffix=".tmp", prefix="board_")
+    try:
+        os.write(fd, data.encode("utf-8"))
+        os.fsync(fd)
+        os.close(fd)
+        os.replace(tmp_path, str(board_path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def update_issue_status(
+    factory_path: Path,
+    issue_number: int,
+    status: str,
+    stage: str | None = None,
+    pr_number: int | None = None,
+    assignee: str | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """Update an issue's status on the board.
+
+    Args:
+        factory_path: Path to factory directory.
+        issue_number: GitHub issue number.
+        status: New status (e.g., "in-progress", "review", "completed").
+        stage: Current pipeline stage.
+        pr_number: Associated PR number.
+        assignee: Agent or person assigned.
+        notes: Additional notes.
+
+    Returns:
+        Updated board data.
+    """
+    board = load_board(factory_path)
+    issues = board.get("issues", {})
+    key = str(issue_number)
+
+    entry = issues.get(key, {"number": issue_number})
+    entry["status"] = status
+    if stage:
+        entry["stage"] = stage
+    if pr_number is not None:
+        entry["pr"] = pr_number
+    if assignee:
+        entry["assignee"] = assignee
+    if notes:
+        entry["notes"] = notes
+
+    issues[key] = entry
+    board["issues"] = issues
+    board["lastUpdated"] = __import__("datetime").datetime.now(
+        __import__("datetime").timezone.utc
+    ).isoformat()
+
+    save_board(factory_path, board)
+    return board
+
+
+def get_issue_entry(factory_path: Path, issue_number: int) -> dict[str, Any] | None:
+    """Get a specific issue entry from the board."""
+    board = load_board(factory_path)
+    return board.get("issues", {}).get(str(issue_number))

--- a/python/src/railclaw_pipeline/github/checkpoint.py
+++ b/python/src/railclaw_pipeline/github/checkpoint.py
@@ -1,0 +1,130 @@
+"""CHECKPOINT.md helpers — create, read, sign-off, archive."""
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class CheckpointError(Exception):
+    """Raised when checkpoint operations fail."""
+    pass
+
+
+CHECKPOINT_PATH = "CHECKPOINT.md"
+ARCHIVE_DIR = ".pipeline-state/archive"
+
+
+def get_checkpoint_path(factory_path: Path) -> Path:
+    """Get path to active CHECKPOINT.md."""
+    return factory_path / CHECKPOINT_PATH
+
+
+def read_checkpoint(factory_path: Path) -> str:
+    """Read current checkpoint content. Returns empty string if missing."""
+    path = get_checkpoint_path(factory_path)
+    if not path.exists():
+        return ""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CheckpointError(f"Failed to read checkpoint: {exc}") from exc
+
+
+def write_checkpoint(factory_path: Path, content: str) -> None:
+    """Write checkpoint atomically."""
+    path = get_checkpoint_path(factory_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    import tempfile
+    import os
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix="checkpoint_")
+    try:
+        os.write(fd, content.encode("utf-8"))
+        os.fsync(fd)
+        os.close(fd)
+        os.replace(tmp_path, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def update_checkpoint(
+    factory_path: Path,
+    stage: str,
+    status: str,
+    issue_number: int | None = None,
+    notes: str | None = None,
+) -> None:
+    """Update CHECKPOINT.md with current stage and status.
+
+    Format:
+    # Pipeline Checkpoint
+    - **Issue:** #N
+    - **Stage:** stage_name
+    - **Status:** status
+    - **Updated:** ISO timestamp
+    - **Notes:** ...
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    issue_line = f"- **Issue:** #{issue_number}" if issue_number else "- **Issue:** N/A"
+    notes_line = f"- **Notes:** {notes}" if notes else ""
+
+    content = f"""# Pipeline Checkpoint
+
+{issue_line}
+- **Stage:** {stage}
+- **Status:** {status}
+- **Updated:** {now}
+{notes_line}
+"""
+    write_checkpoint(factory_path, content)
+
+
+def sign_off_checkpoint(factory_path: Path, sign_off: str) -> None:
+    """Append a sign-off line to the current checkpoint."""
+    existing = read_checkpoint(factory_path)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    sign_line = f"\n---\n✅ Signed off by {sign_off} at {timestamp}\n"
+    write_checkpoint(factory_path, existing + sign_line)
+
+
+def archive_checkpoint(factory_path: Path, issue_number: int) -> Path:
+    """Archive the current checkpoint for an issue.
+
+    Returns path to archived file.
+    """
+    content = read_checkpoint(factory_path)
+    if not content:
+        raise CheckpointError("No checkpoint to archive")
+
+    archive_path = factory_path / ARCHIVE_DIR
+    archive_path.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    dest = archive_path / f"checkpoint-issue-{issue_number}-{timestamp}.md"
+    dest.write_text(content, encoding="utf-8")
+
+    # Clear active checkpoint
+    write_checkpoint(factory_path, "")
+    return dest
+
+
+def parse_checkpoint_stage(factory_path: Path) -> tuple[str, str] | None:
+    """Parse stage and status from checkpoint.
+
+    Returns (stage, status) or None if no checkpoint.
+    """
+    content = read_checkpoint(factory_path)
+    if not content.strip():
+        return None
+
+    stage_match = re.search(r"\*\*Stage:\*\*\s*(.+)", content)
+    status_match = re.search(r"\*\*Status:\*\*\s*(.+)", content)
+
+    if not stage_match or not status_match:
+        return None
+
+    return stage_match.group(1).strip(), status_match.group(1).strip()

--- a/python/src/railclaw_pipeline/github/gh.py
+++ b/python/src/railclaw_pipeline/github/gh.py
@@ -1,0 +1,80 @@
+"""GitHub CLI (gh) wrapper — shell=False with list args."""
+
+from pathlib import Path
+from typing import Any
+
+from railclaw_pipeline.runner.subprocess_runner import SubprocessError, run_subprocess
+
+
+class GhError(Exception):
+    """Raised when a gh CLI command fails."""
+    pass
+
+
+class GhClient:
+    """Wrapper around the gh CLI for GitHub API operations."""
+
+    def __init__(self, repo_path: Path, timeout: float = 60) -> None:
+        self.repo_path = repo_path
+        self.timeout = timeout
+
+    async def _gh(self, *args: str, timeout: float | None = None) -> str:
+        """Run a gh command and return stdout."""
+        cmd = ["gh"] + list(args)
+        try:
+            result = await run_subprocess(
+                cmd,
+                cwd=self.repo_path,
+                timeout=timeout or self.timeout,
+            )
+            return result.stdout.strip()
+        except SubprocessError as exc:
+            raise GhError(f"gh command failed: {' '.join(cmd)}: {exc}") from exc
+
+    async def is_authenticated(self) -> bool:
+        """Check if gh is authenticated."""
+        try:
+            await self._gh("auth", "status", timeout=10)
+            return True
+        except GhError:
+            return False
+
+    async def issue_view(self, number: int) -> dict[str, Any]:
+        """Get issue details as JSON."""
+        output = await self._gh("issue", "view", str(number), "--json", "title,body,labels,assignee,state")
+        import json
+        return json.loads(output)
+
+    async def issue_list(
+        self,
+        milestone: str | None = None,
+        label: str | None = None,
+        state: str = "open",
+        limit: int = 30,
+    ) -> list[dict[str, Any]]:
+        """List issues matching criteria."""
+        args: list[str] = ["issue", "list", "--state", state, "--limit", str(limit), "--json", "number,title,body,labels"]
+        if milestone:
+            args.extend(["--milestone", milestone])
+        if label:
+            args.extend(["--label", label])
+        output = await self._gh(*args, timeout=self.timeout * 2)
+        import json
+        return json.loads(output)
+
+    async def issue_create(
+        self, title: str, body: str, labels: list[str] | None = None, assignee: str | None = None
+    ) -> dict[str, Any]:
+        """Create a new issue."""
+        args: list[str] = ["issue", "create", "--title", title, "--body", body]
+        if labels:
+            args.extend(["--label", ",".join(labels)])
+        if assignee:
+            args.extend(["--assignee", assignee])
+        output = await self._gh(*args, timeout=30)
+        import json
+        return json.loads(output) if output.startswith("{") else {"url": output.strip()}
+
+    async def issue_comment(self, number: int, body: str) -> str:
+        """Add a comment to an issue."""
+        return await self._gh("issue", "comment", str(number), "--body", body, timeout=30)

--- a/python/src/railclaw_pipeline/github/git.py
+++ b/python/src/railclaw_pipeline/github/git.py
@@ -1,0 +1,131 @@
+"""Git operations wrapper — all calls use shell=False with list args."""
+
+import re
+from pathlib import Path
+
+from railclaw_pipeline.runner.subprocess_runner import SubprocessError, run_subprocess
+
+
+# Characters unsafe in branch names — sanitize before use in file paths or commands
+UNSAFE_BRANCH_CHARS = re.compile(r"[^\w./-]")
+
+
+def sanitize_branch_name(branch: str) -> str:
+    """Remove characters unsafe for branch names and file paths."""
+    return UNSAFE_BRANCH_CHARS.sub("_", branch)
+
+
+class GitError(Exception):
+    """Raised when a git operation fails."""
+    pass
+
+
+class GitOperations:
+    """Safe git wrappers for pipeline operations."""
+
+    def __init__(self, repo_path: Path, timeout: float = 120) -> None:
+        self.repo_path = repo_path
+        self.timeout = timeout
+
+    async def _git(self, *args: str, timeout: float | None = None) -> str:
+        """Run a git command and return stdout. Raises GitError on failure."""
+        cmd = ["git"] + list(args)
+        result = await run_subprocess(
+            cmd,
+            cwd=self.repo_path,
+            timeout=timeout or self.timeout,
+        )
+        return result.stdout.strip()
+
+    async def current_branch(self) -> str:
+        """Get the current branch name."""
+        return await self._git("rev-parse", "--abbrev-ref", "HEAD")
+
+    async def is_dirty(self) -> bool:
+        """Check if working tree has uncommitted changes."""
+        result = await self._git("status", "--porcelain")
+        return bool(result)
+
+    async def checkout(self, branch: str) -> str:
+        """Checkout a branch. Returns branch name."""
+        await self._git("checkout", branch)
+        return branch
+
+    async def checkout_new(self, branch: str, base: str = "main") -> str:
+        """Create and checkout a new branch from base."""
+        await self._git("checkout", "-b", branch, base)
+        return branch
+
+    async def fetch(self, remote: str = "origin") -> str:
+        """Fetch from remote."""
+        return await self._git("fetch", remote)
+
+    async def pull(self, remote: str = "origin", branch: str = "main") -> str:
+        """Pull latest changes."""
+        return await self._git("pull", remote, branch)
+
+    async def push(
+        self, remote: str = "origin", branch: str | None = None, set_upstream: bool = False
+    ) -> str:
+        """Push to remote."""
+        args = ["push"]
+        if set_upstream:
+            args.extend(["-u", remote, branch or "HEAD"])
+        else:
+            args.append(remote)
+            if branch:
+                args.append(branch)
+        return await self._git(*args, timeout=self.timeout * 2)
+
+    async def branch_exists(self, branch: str, remote: str = "origin") -> bool:
+        """Check if a branch exists on remote."""
+        try:
+            await self._git("rev-parse", "--verify", f"refs/remotes/{remote}/{branch}", timeout=10)
+            return True
+        except SubprocessError:
+            return False
+
+    async def delete_branch(self, branch: str, force: bool = False) -> None:
+        """Delete a local branch."""
+        flag = "-D" if force else "-d"
+        try:
+            await self._git("branch", flag, branch, timeout=10)
+        except SubprocessError:
+            pass  # Already deleted
+
+    async def delete_remote_branch(self, branch: str, remote: str = "origin") -> None:
+        """Delete a remote branch."""
+        try:
+            await self._git("push", remote, "--delete", branch, timeout=30)
+        except SubprocessError:
+            pass
+
+    async def reset_hard(self, ref: str = "HEAD") -> str:
+        """Reset working tree to ref."""
+        return await self._git("reset", "--hard", ref)
+
+    async def clean(self) -> str:
+        """Remove untracked files and directories."""
+        return await self._git("clean", "-fd")
+
+    async def add(self, *paths: str) -> str:
+        """Stage files."""
+        return await self._git("add", *paths)
+
+    async def commit(self, message: str) -> str:
+        """Create a commit with the given message."""
+        return await self._git("commit", "-m", message)
+
+    async def log(self, count: int = 10, format_str: str = "%h %s") -> str:
+        """Get commit log."""
+        return await self._git("log", f"-{count}", f"--format={format_str}")
+
+    async def ensure_clean(self) -> bool:
+        """Ensure working tree is clean. Returns True if clean, raises if dirty."""
+        if await self.is_dirty():
+            raise GitError("Working tree has uncommitted changes")
+        return True
+
+    async def get_remote_url(self, remote: str = "origin") -> str:
+        """Get the remote URL."""
+        return await self._git("remote", "get-url", remote, timeout=10)

--- a/python/src/railclaw_pipeline/github/git.py
+++ b/python/src/railclaw_pipeline/github/git.py
@@ -7,7 +7,7 @@ from railclaw_pipeline.runner.subprocess_runner import SubprocessError, run_subp
 
 
 # Characters unsafe in branch names — sanitize before use in file paths or commands
-UNSAFE_BRANCH_CHARS = re.compile(r"[^\w./-]")
+UNSAFE_BRANCH_CHARS = re.compile(r"[^\w/-]")
 
 
 def sanitize_branch_name(branch: str) -> str:

--- a/python/src/railclaw_pipeline/github/git.py
+++ b/python/src/railclaw_pipeline/github/git.py
@@ -67,14 +67,13 @@ class GitOperations:
     async def push(
         self, remote: str = "origin", branch: str | None = None, set_upstream: bool = False
     ) -> str:
-        """Push to remote."""
+        """Push to remote with explicit refspec."""
+        ref = branch or await self.current_branch()
         args = ["push"]
         if set_upstream:
-            args.extend(["-u", remote, branch or "HEAD"])
+            args.extend(["-u", remote, f"HEAD:refs/heads/{ref}"])
         else:
-            args.append(remote)
-            if branch:
-                args.append(branch)
+            args.extend([remote, f"HEAD:refs/heads/{ref}"])
         return await self._git(*args, timeout=self.timeout * 2)
 
     async def branch_exists(self, branch: str, remote: str = "origin") -> bool:

--- a/python/src/railclaw_pipeline/github/pr.py
+++ b/python/src/railclaw_pipeline/github/pr.py
@@ -1,5 +1,7 @@
 """PR operations using gh CLI."""
 
+from __future__ import annotations
+
 import json
 from pathlib import Path
 from typing import Any
@@ -55,10 +57,12 @@ class PrClient:
 
         try:
             output = await self.gh._gh(*args, timeout=60)
-            # Parse "https://github.com/owner/repo/pull/123" → extract number
             result: dict[str, Any] = {"url": output.strip()}
             if "/pull/" in output:
-                result["pr_number"] = int(output.strip().rstrip("/").split("/")[-1])
+                pr_num_str = output.strip().rstrip("/").split("/")[-1]
+                if not pr_num_str.isdigit():
+                    raise PrError(f"Failed to extract PR number from URL: {output.strip()}")
+                result["pr_number"] = int(pr_num_str)
             return result
         except GhError as exc:
             raise PrError(f"Failed to create PR: {exc}") from exc

--- a/python/src/railclaw_pipeline/github/pr.py
+++ b/python/src/railclaw_pipeline/github/pr.py
@@ -1,0 +1,154 @@
+"""PR operations using gh CLI."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+from railclaw_pipeline.github.gh import GhClient, GhError
+
+
+class PrError(Exception):
+    """Raised when a PR operation fails."""
+    pass
+
+
+class PrClient:
+    """PR management via gh CLI."""
+
+    def __init__(self, repo_path: Path, timeout: float = 60) -> None:
+        self.gh = GhClient(repo_path, timeout)
+
+    async def create(
+        self,
+        title: str,
+        body: str,
+        base: str = "main",
+        head: str | None = None,
+        draft: bool = False,
+        labels: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create a pull request.
+
+        Args:
+            title: PR title.
+            body: PR body (supports markdown).
+            base: Target branch.
+            head: Source branch (defaults to current).
+            draft: Create as draft PR.
+            labels: Labels to add.
+
+        Returns:
+            Dict with pr_number, url, etc.
+        """
+        args: list[str] = [
+            "pr", "create",
+            "--title", title,
+            "--body", body,
+            "--base", base,
+        ]
+        if head:
+            args.extend(["--head", head])
+        if draft:
+            args.append("--draft")
+        if labels:
+            args.extend(["--label", ",".join(labels)])
+
+        try:
+            output = await self.gh._gh(*args, timeout=60)
+            # Parse "https://github.com/owner/repo/pull/123" → extract number
+            result: dict[str, Any] = {"url": output.strip()}
+            if "/pull/" in output:
+                result["pr_number"] = int(output.strip().rstrip("/").split("/")[-1])
+            return result
+        except GhError as exc:
+            raise PrError(f"Failed to create PR: {exc}") from exc
+
+    async def view(self, number: int, json_fields: str = "number,title,state,mergeable,headRefName") -> dict[str, Any]:
+        """View PR details."""
+        try:
+            output = await self.gh._gh("pr", "view", str(number), "--json", json_fields, timeout=30)
+            return json.loads(output)
+        except GhError as exc:
+            raise PrError(f"Failed to view PR #{number}: {exc}") from exc
+
+    async def is_mergeable(self, number: int) -> tuple[bool, str]:
+        """Check if PR is mergeable. Returns (mergeable, state_string)."""
+        try:
+            data = await self.view(number, json_fields="number,state,mergeable,mergeStateStatus")
+            mergeable = data.get("mergeable", False)
+            state = data.get("mergeStateStatus", "UNKNOWN")
+            return mergeable, state
+        except GhError:
+            return False, "UNKNOWN"
+
+    async def merge(self, number: int, merge_method: str = "squash") -> str:
+        """Merge a PR. Returns merge commit SHA or URL."""
+        try:
+            return await self.gh._gh(
+                "pr", "merge", str(number),
+                "--merge", merge_method,
+                "--delete-branch",
+                timeout=60,
+            )
+        except GhError as exc:
+            raise PrError(f"Failed to merge PR #{number}: {exc}") from exc
+
+    async def comment(self, number: int, body: str) -> str:
+        """Add a comment to a PR."""
+        return await self.gh._gh("pr", "comment", str(number), "--body", body, timeout=30)
+
+    async def list(
+        self,
+        state: str = "open",
+        head: str | None = None,
+        base: str = "main",
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """List PRs."""
+        args: list[str] = [
+            "pr", "list", "--state", state, "--base", base,
+            "--limit", str(limit),
+            "--json", "number,title,headRefName,state,mergeable",
+        ]
+        if head:
+            args.extend(["--head", head])
+        try:
+            output = await self.gh._gh(*args, timeout=30)
+            return json.loads(output)
+        except GhError:
+            return []
+
+    async def comments(self, number: int) -> list[dict[str, Any]]:
+        """Get PR comments."""
+        try:
+            output = await self.gh._gh(
+                "pr", "view", str(number),
+                "--json", "comments",
+                "--jq", ".comments[] | {author: .author.login, body: .body, createdAt: .createdAt}",
+                timeout=30,
+            )
+            if not output.strip():
+                return []
+            return [json.loads(line) for line in output.strip().split("\n") if line.strip()]
+        except (GhError, json.JSONDecodeError):
+            return []
+
+    async def reviews(self, number: int) -> list[dict[str, Any]]:
+        """Get PR reviews."""
+        try:
+            output = await self.gh._gh(
+                "pr", "view", str(number),
+                "--json", "reviews",
+                "--jq", '.reviews[] | {author: .author.login, state: .state, body: .body, submittedAt: .submittedAt}',
+                timeout=30,
+            )
+            if not output.strip():
+                return []
+            return [json.loads(line) for line in output.strip().split("\n") if line.strip()]
+        except (GhError, json.JSONDecodeError):
+            return []
+
+    async def find_by_head(self, head_branch: str) -> dict[str, Any] | None:
+        """Find an open PR by head branch name."""
+        prs = await self.list(state="open", head=head_branch)
+        return prs[0] if prs else None

--- a/python/src/railclaw_pipeline/github/pr.py
+++ b/python/src/railclaw_pipeline/github/pr.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -59,10 +60,10 @@ class PrClient:
             output = await self.gh._gh(*args, timeout=60)
             result: dict[str, Any] = {"url": output.strip()}
             if "/pull/" in output:
-                pr_num_str = output.strip().rstrip("/").split("/")[-1]
-                if not pr_num_str.isdigit():
+                match = re.search(r"/pull/(\d+)", output)
+                if not match:
                     raise PrError(f"Failed to extract PR number from URL: {output.strip()}")
-                result["pr_number"] = int(pr_num_str)
+                result["pr_number"] = int(match.group(1))
             return result
         except GhError as exc:
             raise PrError(f"Failed to create PR: {exc}") from exc
@@ -128,7 +129,7 @@ class PrClient:
             output = await self.gh._gh(
                 "pr", "view", str(number),
                 "--json", "comments",
-                "--jq", ".comments[] | {author: .author.login, body: .body, createdAt: .createdAt}",
+                "--jq", ".comments[] | {author: .author.login, body: .body, createdAt: .createdAt, path: .path, line: .line}",
                 timeout=30,
             )
             if not output.strip():

--- a/python/src/railclaw_pipeline/github/review.py
+++ b/python/src/railclaw_pipeline/github/review.py
@@ -113,6 +113,8 @@ def extract_findings_from_comments(comments: list[dict[str, Any]]) -> list[Revie
             continue
         severity, category = classify_finding(body)
         findings.append(ReviewFinding(
+            file=comment.get("path"),
+            line=comment.get("line"),
             severity=severity,
             category=category,
             description=body[:500],

--- a/python/src/railclaw_pipeline/github/review.py
+++ b/python/src/railclaw_pipeline/github/review.py
@@ -18,6 +18,7 @@ class ReviewFinding:
     line: int | None = None
     severity: str = "info"
     category: str = "general"
+    title: str = ""
     description: str = ""
     raw_text: str = ""
 
@@ -27,6 +28,7 @@ class ReviewFinding:
             "line": self.line,
             "severity": self.severity,
             "category": self.category,
+            "title": self.title,
             "description": self.description,
             "raw_text": self.raw_text,
         }
@@ -52,17 +54,34 @@ class ReviewResult:
         }
 
 
-def parse_details_blocks(text: str) -> list[str]:
-    """Extract content from <details>...</details> blocks in review body."""
-    pattern = re.compile(r"<details[^>]*>(.*?)</details>", re.DOTALL)
-    blocks = []
-    for match in pattern.finditer(text):
-        # Remove summary tags, get content
-        content = re.sub(r"<summary[^>]*>.*?</summary>", "", match.group(1), flags=re.DOTALL)
-        content = content.strip()
-        if content:
-            blocks.append(content)
-    return blocks
+def parse_details_blocks(text: str) -> list[ReviewFinding]:
+    """Extract ReviewFindings from <details>...</details> blocks in review body.
+
+    Parses <summary>Severity: Title</summary> to populate severity and title.
+    Blocks without a <summary> tag are skipped.
+    """
+    details_pattern = re.compile(r"<details[^>]*>(.*?)</details>", re.DOTALL)
+    summary_pattern = re.compile(r"<summary[^>]*>(.*?)</summary>", re.DOTALL)
+    findings: list[ReviewFinding] = []
+    for match in details_pattern.finditer(text):
+        block_content = match.group(1)
+        summary_match = summary_pattern.search(block_content)
+        if not summary_match:
+            continue
+        summary_text = summary_match.group(1).strip()
+        if ": " in summary_text:
+            severity, title = summary_text.split(": ", 1)
+        else:
+            severity = summary_text
+            title = ""
+        body = summary_pattern.sub("", block_content).strip()
+        findings.append(ReviewFinding(
+            severity=severity,
+            title=title,
+            description=body,
+            raw_text=block_content.strip(),
+        ))
+    return findings
 
 
 def classify_finding(text: str) -> tuple[str, str]:
@@ -135,18 +154,11 @@ def extract_findings_from_reviews(reviews: list[dict[str, Any]]) -> list[ReviewF
         # Only process substantive reviews
         if state in ("COMMENTED", "CHANGES_REQUESTED", "APPROVED"):
             # Extract details blocks
-            blocks = parse_details_blocks(body)
-            for block in blocks:
-                severity, category = classify_finding(block)
-                findings.append(ReviewFinding(
-                    severity=severity,
-                    category=category,
-                    description=block[:500],
-                    raw_text=block,
-                ))
+            details_findings = parse_details_blocks(body)
+            findings.extend(details_findings)
 
             # Also check for findings in non-details body
-            if not blocks and state in ("CHANGES_REQUESTED", "COMMENTED"):
+            if not details_findings and state in ("CHANGES_REQUESTED", "COMMENTED"):
                 severity, category = classify_finding(body)
                 findings.append(ReviewFinding(
                     severity=severity,

--- a/python/src/railclaw_pipeline/github/review.py
+++ b/python/src/railclaw_pipeline/github/review.py
@@ -1,0 +1,204 @@
+"""Review parsing and Gemini review polling."""
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from railclaw_pipeline.github.gh import GhClient, GhError
+from railclaw_pipeline.github.pr import PrClient
+
+
+@dataclass
+class ReviewFinding:
+    """A single finding from a code review."""
+    file: str | None = None
+    line: int | None = None
+    severity: str = "info"
+    category: str = "general"
+    description: str = ""
+    raw_text: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "file": self.file,
+            "line": self.line,
+            "severity": self.severity,
+            "category": self.category,
+            "description": self.description,
+            "raw_text": self.raw_text,
+        }
+
+
+@dataclass
+class ReviewResult:
+    """Aggregated result from review parsing."""
+    findings: list[ReviewFinding] = field(default_factory=list)
+    is_clean: bool = True
+    has_formal_review: bool = False
+    last_processed_at: str | None = None
+    raw_comments: list[dict[str, Any]] = field(default_factory=list)
+    raw_reviews: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "is_clean": self.is_clean,
+            "has_formal_review": self.has_formal_review,
+            "finding_count": len(self.findings),
+            "findings": [f.to_dict() for f in self.findings],
+            "last_processed_at": self.last_processed_at,
+        }
+
+
+def parse_details_blocks(text: str) -> list[str]:
+    """Extract content from <details>...</details> blocks in review body."""
+    pattern = re.compile(r"<details[^>]*>(.*?)</details>", re.DOTALL)
+    blocks = []
+    for match in pattern.finditer(text):
+        # Remove summary tags, get content
+        content = re.sub(r"<summary[^>]*>.*?</summary>", "", match.group(1), flags=re.DOTALL)
+        content = content.strip()
+        if content:
+            blocks.append(content)
+    return blocks
+
+
+def classify_finding(text: str) -> tuple[str, str]:
+    """Classify a finding by severity and category.
+
+    Returns (severity, category).
+    """
+    lower = text.lower()
+    # Severity
+    if any(kw in lower for kw in ["critical", "security", "vulnerability", "xss", "injection"]):
+        severity = "critical"
+    elif any(kw in lower for kw in ["error", "bug", "broken", "must", "required"]):
+        severity = "error"
+    elif any(kw in lower for kw in ["warning", "should", "consider", "improve"]):
+        severity = "warning"
+    else:
+        severity = "info"
+
+    # Category
+    if any(kw in lower for kw in ["test", "coverage", "spec"]):
+        category = "testing"
+    elif any(kw in lower for kw in ["security", "xss", "injection", "auth"]):
+        category = "security"
+    elif any(kw in lower for kw in ["type", "typescript", "python", "pydantic"]):
+        category = "types"
+    elif any(kw in lower for kw in ["error handling", "try", "except", "catch"]):
+        category = "error-handling"
+    elif any(kw in lower for kw in ["format", "style", "lint", "ruff", "prettier"]):
+        category = "style"
+    elif any(kw in lower for kw in ["doc", "comment", "readme"]):
+        category = "documentation"
+    else:
+        category = "general"
+
+    return severity, category
+
+
+def extract_findings_from_comments(comments: list[dict[str, Any]]) -> list[ReviewFinding]:
+    """Extract findings from PR inline comments."""
+    findings = []
+    for comment in comments:
+        body = comment.get("body", "").strip()
+        if not body:
+            continue
+        # Skip bot/system comments
+        author = comment.get("author", "")
+        if author in ("github-actions[bot]", "dependabot[bot]"):
+            continue
+        severity, category = classify_finding(body)
+        findings.append(ReviewFinding(
+            severity=severity,
+            category=category,
+            description=body[:500],
+            raw_text=body,
+        ))
+    return findings
+
+
+def extract_findings_from_reviews(reviews: list[dict[str, Any]]) -> list[ReviewFinding]:
+    """Extract findings from PR review bodies and details blocks."""
+    findings = []
+    for review in reviews:
+        state = review.get("state", "")
+        body = review.get("body", "").strip()
+        if not body:
+            continue
+
+        # Only process substantive reviews
+        if state in ("COMMENTED", "CHANGES_REQUESTED", "APPROVED"):
+            # Extract details blocks
+            blocks = parse_details_blocks(body)
+            for block in blocks:
+                severity, category = classify_finding(block)
+                findings.append(ReviewFinding(
+                    severity=severity,
+                    category=category,
+                    description=block[:500],
+                    raw_text=block,
+                ))
+
+            # Also check for findings in non-details body
+            if not blocks and state in ("CHANGES_REQUESTED", "COMMENTED"):
+                severity, category = classify_finding(body)
+                findings.append(ReviewFinding(
+                    severity=severity,
+                    category=category,
+                    description=body[:500],
+                    raw_text=body,
+                ))
+
+    return findings
+
+
+async def poll_reviews(
+    pr_client: PrClient,
+    pr_number: int,
+    last_processed_at: str | None = None,
+) -> ReviewResult:
+    """Poll PR comments and reviews for new findings.
+
+    Args:
+        pr_client: PR client instance.
+        pr_number: PR number to poll.
+        last_processed_at: ISO timestamp to filter old findings.
+
+    Returns:
+        ReviewResult with aggregated findings.
+    """
+    comments = await pr_client.comments(pr_number)
+    reviews = await pr_client.reviews(pr_number)
+
+    # Filter by timestamp if provided
+    if last_processed_at:
+        try:
+            cutoff = datetime.fromisoformat(last_processed_at.replace("Z", "+00:00"))
+            comments = [
+                c for c in comments
+                if datetime.fromisoformat(c.get("createdAt", "").replace("Z", "+00:00")) > cutoff
+            ]
+            reviews = [
+                r for r in reviews
+                if datetime.fromisoformat(r.get("submittedAt", "").replace("Z", "+00:00")) > cutoff
+            ]
+        except (ValueError, TypeError):
+            pass  # If parsing fails, process all
+
+    findings = extract_findings_from_comments(comments)
+    findings.extend(extract_findings_from_reviews(reviews))
+
+    has_formal = any(r.get("state") in ("APPROVED", "CHANGES_REQUESTED") for r in reviews)
+
+    return ReviewResult(
+        findings=findings,
+        is_clean=len(findings) == 0,
+        has_formal_review=has_formal,
+        last_processed_at=datetime.now(timezone.utc).isoformat(),
+        raw_comments=comments,
+        raw_reviews=reviews,
+    )

--- a/python/src/railclaw_pipeline/milestone/__init__.py
+++ b/python/src/railclaw_pipeline/milestone/__init__.py
@@ -1,0 +1,1 @@
+"""Milestone mode — multi-issue collection and sequential execution."""

--- a/python/src/railclaw_pipeline/milestone/collector.py
+++ b/python/src/railclaw_pipeline/milestone/collector.py
@@ -1,0 +1,84 @@
+"""Milestone issue collector — gather issues from gh milestone."""
+
+import logging
+from typing import Any
+
+from railclaw_pipeline.github.gh import GhClient
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+async def collect_milestone_issues(
+    repo_path: Path,
+    milestone: str,
+    state_filter: str = "open",
+) -> list[dict[str, Any]]:
+    """Collect all issues in a GitHub milestone.
+
+    Args:
+        repo_path: Path to the git repository.
+        milestone: Milestone title or number.
+        state_filter: Issue state filter (open, closed, all).
+
+    Returns:
+        List of issue dicts with number, title, body, labels.
+    """
+    gh = GhClient(repo_path)
+    issues = await gh.issue_list(
+        milestone=milestone,
+        state=state_filter,
+        limit=50,
+    )
+
+    if not issues:
+        logger.warning("No issues found in milestone '%s'", milestone)
+        return []
+
+    logger.info(
+        "Collected %d issues from milestone '%s'",
+        len(issues),
+        milestone,
+    )
+    return issues
+
+
+def parse_plan_issues(plan_path: Path) -> list[int]:
+    """Extract issue numbers from PLAN.md execution order.
+
+    Looks for patterns like:
+      ## Execution Order
+      1. #65 — Fetch queue utility
+      2. #72 — Rate limiter
+    """
+    import re
+
+    if not plan_path.exists():
+        return []
+
+    content = plan_path.read_text(encoding="utf-8")
+
+    numbers = []
+    in_execution_section = False
+    for line in content.splitlines():
+        stripped = line.strip()
+
+        if "execution order" in stripped.lower():
+            in_execution_section = True
+            continue
+
+        if in_execution_section:
+            if stripped.startswith("#") and not stripped.startswith("# "):
+                break
+
+            matches = re.findall(r"#(\d+)", stripped)
+            for m in matches:
+                num = int(m)
+                if num not in numbers:
+                    numbers.append(num)
+
+            if not stripped:
+                if numbers:
+                    break
+
+    return numbers

--- a/python/src/railclaw_pipeline/milestone/runner.py
+++ b/python/src/railclaw_pipeline/milestone/runner.py
@@ -1,0 +1,185 @@
+"""Milestone runner — sequential per-issue execution with state reset."""
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.milestone.collector import collect_milestone_issues, parse_plan_issues
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentRunner
+from railclaw_pipeline.state.models import PipelineState, PipelineStatus
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+async def run_milestone(
+    milestone_label: str,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    blueprint_runner: AgentRunner,
+    pipeline_func: Any,
+) -> list[dict[str, Any]]:
+    """Run the full pipeline for all issues in a milestone.
+
+    Steps:
+    1. Collect all milestone issues
+    2. Run Blueprint holistically for all issues
+    3. Parse PLAN.md for execution order
+    4. Execute each issue sequentially with state reset
+
+    Args:
+        milestone_label: GitHub milestone title.
+        config: Pipeline configuration.
+        emitter: Event emitter.
+        blueprint_runner: Agent runner for Blueprint.
+        pipeline_func: The run_pipeline function to call per issue.
+
+    Returns:
+        List of result dicts per issue.
+    """
+    emitter.emit("milestone_start", milestone=milestone_label)
+
+    issues = await collect_milestone_issues(config.repo_path, milestone_label)
+    if not issues:
+        emitter.emit("milestone_empty", milestone=milestone_label)
+        return []
+
+    issue_summaries = [
+        {"number": i.get("number"), "title": i.get("title", ""), "body": i.get("body", "")}
+        for i in issues
+    ]
+
+    emitter.emit("milestone_issues_collected", milestone=milestone_label, count=len(issues))
+
+    context = {
+        "milestone": milestone_label,
+        "issues": issue_summaries,
+        "issue_count": len(issues),
+        "repo_path": str(config.repo_path),
+    }
+
+    prompt = render_template(config.factory_path, "blueprint.j2", context)
+    if not prompt:
+        prompt = _build_milestone_blueprint_prompt(milestone_label, issue_summaries)
+
+    emitter.emit("agent_start", issue=0, agent="blueprint", cli="opencode", milestone=milestone_label)
+    result = await blueprint_runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=0,
+        agent="blueprint",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+        milestone=milestone_label,
+    )
+
+    if not result.success:
+        raise RuntimeError(
+            f"Milestone Blueprint failed: {result.error or result.stderr[:500]}"
+        )
+
+    plan_path = config.factory_path / "PLAN.md"
+    issue_numbers = parse_plan_issues(plan_path)
+
+    if not issue_numbers:
+        issue_numbers = [i["number"] for i in issue_summaries]
+        logger.warning(
+            "No execution order found in PLAN.md, using collection order: %s",
+            issue_numbers,
+        )
+
+    results = []
+    for idx, issue_num in enumerate(issue_numbers):
+        emitter.emit(
+            "milestone_issue_start",
+            milestone=milestone_label,
+            issue=issue_num,
+            index=idx + 1,
+            total=len(issue_numbers),
+        )
+
+        state = PipelineState(
+            issue_number=issue_num,
+            milestone_mode=True,
+            milestone_label=milestone_label,
+            repo_path=str(config.repo_path),
+            timestamps=__import__("railclaw_pipeline.state.models", fromlist=["Timestamps"]).Timestamps(
+                started=datetime.now(timezone.utc),
+                stage_entered=datetime.now(timezone.utc),
+                last_updated=datetime.now(timezone.utc),
+            ),
+        )
+        save_state(state, config.state_path)
+
+        try:
+            await pipeline_func(state, config, emitter)
+            results.append({
+                "issue": issue_num,
+                "status": "success",
+            })
+        except Exception as exc:
+            logger.error(
+                "Milestone issue #%d failed: %s",
+                issue_num,
+                exc,
+                exc_info=True,
+            )
+            results.append({
+                "issue": issue_num,
+                "status": "failed",
+                "error": str(exc),
+            })
+            emitter.emit(
+                "milestone_issue_failed",
+                milestone=milestone_label,
+                issue=issue_num,
+                error=str(exc),
+            )
+
+        if idx < len(issue_numbers) - 1:
+            git_ops = GitOperations(config.repo_path)
+            try:
+                await git_ops.checkout("main")
+                await git_ops.pull("origin", "main")
+            except Exception:
+                logger.warning("Failed to reset to main between milestone issues", exc_info=True)
+
+    success_count = sum(1 for r in results if r["status"] == "success")
+    emitter.emit(
+        "milestone_complete",
+        milestone=milestone_label,
+        total=len(issue_numbers),
+        succeeded=success_count,
+        failed=len(issue_numbers) - success_count,
+    )
+
+    return results
+
+
+def _build_milestone_blueprint_prompt(milestone: str, issues: list[dict]) -> str:
+    issues_text = "\n".join(
+        f"  - #{i['number']}: {i['title']}"
+        for i in issues
+    )
+    return (
+        "You are Blueprint, the planning agent.\n\n"
+        f"Create a holistic plan for milestone '{milestone}' covering {len(issues)} issues:\n"
+        f"{issues_text}\n\n"
+        "Produce a single PLAN.md with:\n"
+        "1. Overall milestone goal\n"
+        "2. Execution order (with issue numbers)\n"
+        "3. Per-issue phase breakdowns\n"
+        "4. Cross-issue dependencies\n\n"
+        "Format the execution order as:\n"
+        "## Execution Order\n"
+        "1. #N — Issue title\n"
+        "2. #M — Issue title\n\n"
+        "Before starting, read factory/AGENT-RULES.md.\n\n"
+        "RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/pipeline.py
+++ b/python/src/railclaw_pipeline/pipeline.py
@@ -62,6 +62,7 @@ STAGE_PHASE_MAP: dict[str, tuple[str, str]] = {
     "stage8c_merge": ("merge", "merged"),
     "stage9_deploy": ("merge", "merged"),
     "stage10_qa": ("qa", "in-progress"),
+    "stage11_hotfix": ("hotfix", "in-progress"),
     "stage12_lessons": ("merge", "closed"),
 }
 
@@ -135,6 +136,7 @@ async def run_pipeline(
     state: PipelineState,
     config: PipelineConfig,
     emitter: EventEmitter,
+    hotfix: bool = False,
 ) -> None:
     """Execute the full pipeline from current stage to completion."""
     from railclaw_pipeline.stages.stage0_preflight import run_preflight
@@ -151,6 +153,7 @@ async def run_pipeline(
     from railclaw_pipeline.stages.stage8c_merge import run_merge
     from railclaw_pipeline.stages.stage9_deploy import run_deploy
     from railclaw_pipeline.stages.stage10_qa import run_qa
+    from railclaw_pipeline.stages.stage11_hotfix import run_hotfix
     from railclaw_pipeline.stages.stage12_lessons import run_lessons
 
     blueprint_config = _get_agent_config(config, "blueprint")
@@ -158,6 +161,18 @@ async def run_pipeline(
     scope_config = _get_agent_config(config, "scope")
 
     try:
+        if hotfix:
+            wrench_runner = AgentRunner(_get_agent_config(config, "wrench"), config.repo_path)
+            scope_runner = AgentRunner(_get_agent_config(config, "scope"), config.repo_path)
+            state = await run_stage(
+                "stage11_hotfix", run_hotfix, state, config, emitter,
+                wrench_runner, scope_runner,
+            )
+            state.status = PipelineStatus.COMPLETED
+            save_state(state, config.state_path)
+            emitter.emit("pipeline_complete", issue=state.issue_number)
+            return
+
         state = await run_stage("stage0_preflight", run_preflight, state, config, emitter)
         state = await run_stage(
             "stage1_blueprint", run_blueprint, state, config, emitter,

--- a/python/src/railclaw_pipeline/pipeline.py
+++ b/python/src/railclaw_pipeline/pipeline.py
@@ -1,0 +1,314 @@
+"""Main pipeline runner — orchestrates stage execution."""
+
+import asyncio
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Awaitable
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.board import update_issue_status
+from railclaw_pipeline.github.checkpoint import (
+    archive_checkpoint,
+    update_checkpoint,
+)
+from railclaw_pipeline.runner.agent import AgentRunner
+from railclaw_pipeline.state.models import PipelineStage, PipelineState, PipelineStatus
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+class FatalPipelineError(Exception):
+    """Unrecoverable pipeline error — sets status to failed."""
+
+    def __init__(self, category: str, message: str) -> None:
+        super().__init__(message)
+        self.category = category
+
+
+STAGE_TIMEOUTS: dict[str, float] = {
+    "stage0_preflight": 120,
+    "stage1_blueprint": 600,
+    "stage2_wrench": 7200,
+    "stage2.5_create_pr": 60,
+    "stage3_audit": 300,
+    "stage3.5_audit_fix": 600,
+    "stage4_review": 300,
+    "stage5_fix_loop": 600,
+    "cycle2_gemini_loop": 1200,
+    "stage7_docs": 600,
+    "stage8_approval": 86400,
+    "stage8c_merge": 120,
+    "stage9_deploy": 300,
+    "stage10_qa": 600,
+    "stage11_hotfix": 1800,
+    "stage12_lessons": 120,
+}
+
+STAGE_PHASE_MAP: dict[str, tuple[str, str]] = {
+    "stage0_preflight": ("blueprint", "planning"),
+    "stage1_blueprint": ("blueprint", "in-progress"),
+    "stage2_wrench": ("coding", "in-progress"),
+    "stage2.5_create_pr": ("pr-creation", "in-progress"),
+    "stage3_audit": ("audit", "in-review"),
+    "stage3.5_audit_fix": ("fix", "in-review"),
+    "stage4_review": ("review", "in-review"),
+    "stage5_fix_loop": ("fix", "in-review"),
+    "cycle2_gemini_loop": ("review", "in-review"),
+    "stage7_docs": ("docs", "in-progress"),
+    "stage8c_merge": ("merge", "merged"),
+    "stage9_deploy": ("merge", "merged"),
+    "stage10_qa": ("qa", "in-progress"),
+    "stage12_lessons": ("merge", "closed"),
+}
+
+
+async def run_stage(
+    name: str,
+    handler: Callable[..., Awaitable[PipelineState]],
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    *args: Any,
+) -> PipelineState:
+    """Execute a pipeline stage with timeout, event emission, and state persistence."""
+    start = time.monotonic()
+    state.stage = PipelineStage(name)
+    state.status = PipelineStatus.RUNNING
+    if state.timestamps:
+        state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+
+    emitter.emit("stage_start", issue=state.issue_number, stage=name)
+    update_checkpoint(
+        config.factory_path, stage=name, status="running", issue_number=state.issue_number
+    )
+
+    timeout = STAGE_TIMEOUTS.get(name)
+    try:
+        state = await asyncio.wait_for(
+            handler(state, config, emitter, *args),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        duration = time.monotonic() - start
+        emitter.emit(
+            "stage_end", issue=state.issue_number, stage=name,
+            duration_s=duration, payload={"success": False, "timeout": True},
+        )
+        raise
+    except FatalPipelineError:
+        raise
+    except Exception as exc:
+        duration = time.monotonic() - start
+        emitter.emit(
+            "stage_end", issue=state.issue_number, stage=name,
+            duration_s=duration, payload={"success": False, "error": str(exc)},
+        )
+        raise
+
+    duration = time.monotonic() - start
+    emitter.emit(
+        "stage_end", issue=state.issue_number, stage=name,
+        duration_s=duration, payload={"success": True},
+    )
+
+    phase, board_status = STAGE_PHASE_MAP.get(name, ("unknown", "in-progress"))
+    try:
+        update_issue_status(
+            config.factory_path, state.issue_number, board_status, stage=name,
+            pr_number=state.pr_number,
+        )
+    except Exception:
+        logger.warning("Board update failed for stage %s", name, exc_info=True)
+
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+async def run_pipeline(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+) -> None:
+    """Execute the full pipeline from current stage to completion."""
+    from railclaw_pipeline.stages.stage0_preflight import run_preflight
+    from railclaw_pipeline.stages.stage1_blueprint import run_blueprint
+    from railclaw_pipeline.stages.stage2_wrench import run_wrench
+    from railclaw_pipeline.stages.stage2_5_pr import run_create_pr
+    from railclaw_pipeline.stages.stage3_audit import run_audit
+    from railclaw_pipeline.stages.stage3_5_fix import run_audit_fix
+    from railclaw_pipeline.stages.stage4_review import run_review
+    from railclaw_pipeline.stages.stage5_fix_loop import run_fix_loop
+    from railclaw_pipeline.stages.cycle2_gemini import run_gemini_loop
+    from railclaw_pipeline.stages.stage7_docs import run_docs
+    from railclaw_pipeline.stages.stage8_approval import run_approval
+    from railclaw_pipeline.stages.stage8c_merge import run_merge
+    from railclaw_pipeline.stages.stage9_deploy import run_deploy
+    from railclaw_pipeline.stages.stage10_qa import run_qa
+    from railclaw_pipeline.stages.stage12_lessons import run_lessons
+
+    blueprint_config = _get_agent_config(config, "blueprint")
+    wrench_config = _get_agent_config(config, "wrench")
+    scope_config = _get_agent_config(config, "scope")
+
+    try:
+        state = await run_stage("stage0_preflight", run_preflight, state, config, emitter)
+        state = await run_stage(
+            "stage1_blueprint", run_blueprint, state, config, emitter,
+            AgentRunner(blueprint_config, config.repo_path),
+        )
+        state = await run_stage(
+            "stage2_wrench", run_wrench, state, config, emitter,
+            AgentRunner(wrench_config, config.repo_path),
+        )
+        state = await run_stage("stage2.5_create_pr", run_create_pr, state, config, emitter)
+
+        state = await run_stage(
+            "stage3_audit", run_audit, state, config, emitter,
+            AgentRunner(scope_config, config.repo_path),
+        )
+
+        current_findings = state.findings.get("current", [])
+        if current_findings:
+            state = await run_stage(
+                "stage3.5_audit_fix", run_audit_fix, state, config, emitter,
+                AgentRunner(wrench_config, config.repo_path),
+            )
+        else:
+            emitter.emit("audit_clean", issue=state.issue_number, stage="stage3_audit")
+
+        for rnd in range(5):
+            state.cycle.cycle1_round = rnd
+            save_state(state, config.state_path)
+
+            state = await run_stage(
+                "stage4_review", run_review, state, config, emitter,
+                AgentRunner(scope_config, config.repo_path),
+            )
+
+            if state.cycle.scope_verdict == "pass":
+                break
+
+            if rnd == 4:
+                emitter.emit("escalation", issue=state.issue_number, payload={
+                    "type": "fix_loop_exhausted",
+                    "round": 5,
+                    "message": "Fix loop exhausted 5 rounds. Escalation to Chris.",
+                })
+
+            state = await run_stage(
+                "stage5_fix_loop", run_fix_loop, state, config, emitter,
+                AgentRunner(wrench_config, config.repo_path),
+            )
+
+        cycle2_cap = 20
+        prev_count = -1
+        stall = 0
+        while not state.cycle.gemini_clean and state.cycle.cycle2_round < cycle2_cap:
+            state = await run_stage(
+                "cycle2_gemini_loop", run_gemini_loop, state, config, emitter,
+                AgentRunner(scope_config, config.repo_path),
+            )
+            state.cycle.cycle2_round += 1
+            save_state(state, config.state_path)
+
+            cur_count = len(state.findings.get("current", []))
+            if cur_count >= prev_count:
+                stall += 1
+            else:
+                stall = 0
+            prev_count = cur_count
+
+            if stall >= 2:
+                emitter.emit("cycle2_not_converging", issue=state.issue_number, payload={
+                    "rounds": state.cycle.cycle2_round,
+                    "findings": cur_count,
+                })
+                stall = 0
+
+        if not state.cycle.gemini_clean and state.cycle.cycle2_round >= cycle2_cap:
+            raise FatalPipelineError(
+                "cycle2_safety_cap",
+                f"Gemini review loop did not achieve clean status after {cycle2_cap} rounds",
+            )
+
+        state = await run_stage("stage7_docs", run_docs, state, config, emitter)
+        state = await run_stage("stage8_approval", run_approval, state, config, emitter)
+        state = await run_stage("stage8c_merge", run_merge, state, config, emitter)
+        state = await run_stage("stage9_deploy", run_deploy, state, config, emitter)
+        state = await run_stage(
+            "stage10_qa", run_qa, state, config, emitter,
+            AgentRunner(_get_agent_config(config, "beaker"), config.repo_path),
+        )
+
+        state.status = PipelineStatus.COMPLETED
+        save_state(state, config.state_path)
+        emitter.emit("pipeline_complete", issue=state.issue_number)
+
+    except FatalPipelineError as exc:
+        state.status = PipelineStatus.FAILED
+        state.error = {"category": exc.category, "message": str(exc), "stage": state.stage.value}
+        save_state(state, config.state_path)
+        emitter.emit("fatal_error", issue=state.issue_number, payload={
+            "category": exc.category, "message": str(exc),
+        })
+    except asyncio.TimeoutError:
+        state.status = PipelineStatus.FAILED
+        state.error = {"category": "timeout", "message": f"Stage {state.stage.value} timed out"}
+        save_state(state, config.state_path)
+        emitter.emit("fatal_error", issue=state.issue_number, payload={
+            "category": "timeout", "message": f"Stage {state.stage.value} timed out",
+        })
+    except Exception as exc:
+        state.status = PipelineStatus.FAILED
+        state.error = {"category": "unhandled", "message": str(exc), "stage": state.stage.value}
+        save_state(state, config.state_path)
+        emitter.emit("fatal_error", issue=state.issue_number, payload={
+            "category": "unhandled", "message": str(exc),
+        })
+    finally:
+        from railclaw_pipeline.stages.stage12_lessons import run_lessons
+        try:
+            await run_lessons(state, config, emitter)
+        except Exception as lessons_err:
+            logger.warning("Failed to write lessons learned: %s", lessons_err)
+        try:
+            archive_checkpoint(config.factory_path, state.issue_number)
+        except Exception as cp_err:
+            logger.warning("Failed to archive checkpoint: %s", cp_err)
+
+
+def _get_agent_config(config: PipelineConfig, agent_name: str) -> "AgentConfig":
+    from railclaw_pipeline.runner.agent import AgentConfig
+
+    agent_cfg = config.agents.get(agent_name, {})
+    model = agent_cfg.get("model", "")
+    timeout = agent_cfg.get("timeout", 600)
+
+    workdir = config.repo_path
+    command = "opencode"
+    args_template = ["run", "--dir", str(workdir), "{prompt}"]
+
+    if agent_name in ("wrenchSr", "scout"):
+        command = "gemini"
+        args_template = ["--model", model, "{prompt}"]
+    elif agent_name in ("blueprint", "wrench", "scope", "beaker", "quill"):
+        env_dir = config.factory_path / "envs" / agent_name
+        if env_dir.exists():
+            workdir = env_dir
+        args_template = ["run", "--dir", str(workdir), "--timeout", str(timeout), "{prompt}"]
+
+    return AgentConfig(
+        name=agent_name,
+        model=model,
+        timeout=timeout,
+        command=command,
+        args_template=args_template,
+        workdir=workdir,
+    )

--- a/python/src/railclaw_pipeline/prompts/__init__.py
+++ b/python/src/railclaw_pipeline/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt template loading and rendering."""

--- a/python/src/railclaw_pipeline/prompts/loader.py
+++ b/python/src/railclaw_pipeline/prompts/loader.py
@@ -4,7 +4,8 @@ import re
 from pathlib import Path
 from typing import Any
 
-from jinja2 import BaseLoader, Environment, StrictUndefined, TemplateSyntaxError, select_autoescape
+from jinja2 import BaseLoader, StrictUndefined, TemplateSyntaxError, select_autoescape
+from jinja2.sandbox import SandboxedEnvironment
 
 
 class SandboxedTemplateError(Exception):
@@ -74,22 +75,23 @@ class FactoryTemplateLoader(BaseLoader):
         return any(u.lower() in lower for u in unsafe)
 
 
-def create_template_env(factory_path: Path) -> Environment:
+def create_template_env(factory_path: Path) -> SandboxedEnvironment:
     """Create a sandboxed Jinja2 environment for factory templates.
+
+    Uses jinja2.sandbox.SandboxedEnvironment for proper SSTI protection
+    instead of blacklist-based pattern filtering.
 
     - StrictUndefined: variables must be defined
     - autoescape: disabled (we output text, not HTML)
     - No access to Python internals
     """
     loader = FactoryTemplateLoader(factory_path)
-    env = Environment(
+    env = SandboxedEnvironment(
         loader=loader,
         undefined=StrictUndefined,
         autoescape=select_autoescape(default=False),
         keep_trailing_newline=True,
     )
-    # Remove dangerous globals
-    env.globals.pop("range", None)  # we'll add back a safe version
     return env
 
 

--- a/python/src/railclaw_pipeline/prompts/loader.py
+++ b/python/src/railclaw_pipeline/prompts/loader.py
@@ -1,0 +1,135 @@
+"""Jinja2 template loader from factory/ directory with sandboxed rendering."""
+
+import re
+from pathlib import Path
+from typing import Any
+
+from jinja2 import BaseLoader, Environment, StrictUndefined, TemplateSyntaxError, select_autoescape
+
+
+class SandboxedTemplateError(Exception):
+    """Raised when template rendering fails or is unsafe."""
+    pass
+
+
+class FactoryTemplateLoader(BaseLoader):
+    """Loads Jinja2 templates from the factory/ directory.
+
+    Templates are loaded from factory/ relative paths.
+    Only .j2 files are allowed.
+    """
+
+    def __init__(self, factory_path: Path, templates_dir: str = "prompts/templates") -> None:
+        self.factory_path = factory_path
+        self.templates_dir = factory_path / templates_dir
+        # Also support loading from plugin's bundled templates
+        self.bundled_dir = Path(__file__).parent / "templates"
+
+    def get_source(self, environment: Any, template: str) -> tuple[str, str, callable]:
+        """Get template source from factory or bundled templates.
+
+        Template names are sanitized to prevent directory traversal.
+        """
+        # Sanitize template name — no path traversal
+        if ".." in template or template.startswith("/"):
+            raise TemplateSyntaxError(f"Invalid template name: {template}", 0)
+
+        # Only allow .j2 extension
+        if not template.endswith(".j2"):
+            raise TemplateSyntaxError(f"Template must have .j2 extension: {template}", 0)
+
+        # Remove any non-alphanumeric/path characters
+        safe_name = re.sub(r"[^\w./-]", "", template)
+
+        # Try factory templates first, then bundled
+        for base in [self.templates_dir, self.bundled_dir]:
+            path = base / safe_name
+            if path.exists() and path.is_file():
+                source = path.read_text(encoding="utf-8")
+                # Check for obvious SSTI attempts
+                if self._has_unsafe_patterns(source):
+                    raise SandboxedTemplateError(f"Potentially unsafe template: {template}")
+                return source, str(path), lambda: False  # not cached
+
+        raise TemplateSyntaxError(f"Template not found: {template}", 0)
+
+    def _has_unsafe_patterns(self, source: str) -> bool:
+        """Check for obviously unsafe Jinja2 patterns."""
+        # These would require explicit sandbox bypass
+        unsafe = [
+            "__import__",
+            "__class__",
+            "__mro__",
+            "__subclasses__",
+            "__builtins__",
+            "os.system",
+            "subprocess",
+            "eval(",
+            "exec(",
+            "open(",
+            "getattr(",
+            "setattr(",
+        ]
+        lower = source.lower()
+        return any(u.lower() in lower for u in unsafe)
+
+
+def create_template_env(factory_path: Path) -> Environment:
+    """Create a sandboxed Jinja2 environment for factory templates.
+
+    - StrictUndefined: variables must be defined
+    - autoescape: disabled (we output text, not HTML)
+    - No access to Python internals
+    """
+    loader = FactoryTemplateLoader(factory_path)
+    env = Environment(
+        loader=loader,
+        undefined=StrictUndefined,
+        autoescape=select_autoescape(default=False),
+        keep_trailing_newline=True,
+    )
+    # Remove dangerous globals
+    env.globals.pop("range", None)  # we'll add back a safe version
+    return env
+
+
+def render_template(
+    factory_path: Path,
+    template_name: str,
+    context: dict[str, Any],
+) -> str:
+    """Render a template with the given context.
+
+    Args:
+        factory_path: Path to factory directory.
+        template_name: Name of the .j2 template file.
+        context: Variables to pass to the template.
+
+    Returns:
+        Rendered template string.
+
+    Raises:
+        SandboxedTemplateError: If template is unsafe or not found.
+    """
+    env = create_template_env(factory_path)
+    try:
+        template = env.get_template(template_name)
+        return template.render(**context)
+    except TemplateSyntaxError as exc:
+        raise SandboxedTemplateError(f"Template error: {exc}") from exc
+
+
+def load_prompt_text(factory_path: Path, prompt_name: str) -> str:
+    """Load a raw prompt template text without rendering.
+
+    Falls back to built-in prompts if factory template doesn't exist.
+    """
+    safe_name = re.sub(r"[^\w./-]", "", prompt_name)
+    for base in [
+        factory_path / "prompts" / "templates",
+        Path(__file__).parent / "templates",
+    ]:
+        path = base / f"{safe_name}.j2"
+        if path.exists():
+            return path.read_text(encoding="utf-8")
+    raise SandboxedTemplateError(f"Prompt template not found: {prompt_name}")

--- a/python/src/railclaw_pipeline/prompts/templates/beaker_qa.j2
+++ b/python/src/railclaw_pipeline/prompts/templates/beaker_qa.j2
@@ -1,0 +1,32 @@
+You are Beaker, the QA agent for the coding factory.
+
+**Task:** Perform QA validation on the deployed changes.
+
+**Issue:** #{{ issue_number }}
+**Branch:** {{ branch }}
+**PR:** #{{ pr_number }}
+
+**Instructions:**
+1. Verify the deployment is healthy
+2. Check PLAN.md completeness against live implementation
+3. Test critical paths described in the issue
+4. Verify no regressions in existing functionality
+5. Check logs for errors or warnings
+
+**For each finding:**
+```
+QA_START
+severity: critical|error|warning|info
+area: functionality|performance|security|usability
+description: What was tested and what was found
+QA_END
+```
+
+**Final output:**
+```
+QA_RESULT_START
+verdict: pass|fail
+critical_issues: N
+total_findings: N
+QA_RESULT_END
+```

--- a/python/src/railclaw_pipeline/prompts/templates/blueprint.j2
+++ b/python/src/railclaw_pipeline/prompts/templates/blueprint.j2
@@ -1,0 +1,33 @@
+You are Blueprint, the planning agent for the coding factory.
+
+**Task:** Create a detailed implementation plan for the following GitHub issue.
+
+**Issue:** #{{ issue_number }} — {{ issue_title }}
+**Body:**
+{{ issue_body }}
+
+**Repository:** {{ repo_name }}
+**Branch:** {{ branch }}
+
+**Instructions:**
+1. Analyze the issue requirements thoroughly
+2. Break the work into implementation phases
+3. For each phase, specify:
+   - Files to create/modify
+   - Key implementation details
+   - Dependencies on other phases
+   - Tests required
+4. Consider edge cases and error handling
+5. Follow the existing code patterns in the repository
+
+**Output:** Write the plan to PLAN.md in the repository root. Use the format:
+```
+# PLAN.md — [Repo Name]: [Issue Title]
+## Phase 1: ...
+### Deliverables
+- [ ] ...
+### Tests
+- [ ] ...
+```
+
+Each phase must be self-contained and independently testable.

--- a/python/src/railclaw_pipeline/prompts/templates/quill_docs.j2
+++ b/python/src/railclaw_pipeline/prompts/templates/quill_docs.j2
@@ -1,0 +1,23 @@
+You are Quill, the documentation agent.
+
+Review and update documentation for issue #{{ issue_number }}.
+Branch: {{ branch }}
+{% if pr_number %}PR: #{{ pr_number }}{% endif %}
+
+Check:
+- README.md
+- ARCHITECTURE.md
+- docs/* directory
+- Inline documentation (JSDoc, docstrings)
+
+Rules:
+- Doc-only changes — NO code changes, NO test changes
+- Commit prefix MUST be "docs: <description>"
+- Major doc work that can't be completed here → note as follow-up issue
+- Advisory — does NOT block merge
+
+Before starting, read factory/AGENT-RULES.md.
+
+RESULT_START
+status: success
+RESULT_END

--- a/python/src/railclaw_pipeline/prompts/templates/scope_audit.j2
+++ b/python/src/railclaw_pipeline/prompts/templates/scope_audit.j2
@@ -1,0 +1,41 @@
+You are Scope, the audit agent for the coding factory.
+
+**Task:** Perform a completeness audit on the implementation.
+
+**Issue:** #{{ issue_number }}
+**Branch:** {{ branch }}
+**PR:** #{{ pr_number }} (if created)
+
+**Instructions:**
+1. Read the PLAN.md for expected deliverables
+2. Check each deliverable against the actual implementation
+3. For each finding, classify as:
+   - **[COMPLETENESS]** Missing deliverable or incomplete implementation
+   - **[HARDENING]** Missing error handling, input validation, or edge cases
+   - **[POLISH]** Style, documentation, naming improvements
+
+**Rules:**
+- Report ALL findings, even minor ones
+- Never pre-validate — if something looks wrong, report it
+- Be specific: include file paths, line numbers, and expected vs actual
+- Each finding must be actionable
+
+**Output format:**
+```
+FINDING_START
+category: completeness|hardening|polish
+file: path/to/file
+description: What's wrong and how to fix it
+FINDING_END
+```
+
+End with:
+```
+AUDIT_START
+total_findings: N
+completeness: N
+hardening: N
+polish: N
+verdict: pass|revision
+AUDIT_END
+```

--- a/python/src/railclaw_pipeline/prompts/templates/scope_review.j2
+++ b/python/src/railclaw_pipeline/prompts/templates/scope_review.j2
@@ -1,0 +1,35 @@
+You are Scope, the code review agent for the coding factory.
+
+**Task:** Perform a thorough code review of the PR changes.
+
+**Issue:** #{{ issue_number }}
+**Branch:** {{ branch }}
+**PR:** #{{ pr_number }}
+
+**Review Focus Areas:**
+1. Correctness — does the code do what PLAN.md specifies?
+2. Error handling — are edge cases covered?
+3. Security — any injection vectors, missing validation?
+4. Performance — any obvious bottlenecks?
+5. Testing — adequate coverage?
+
+**Instructions:**
+1. Review all changed files
+2. For each finding, provide file, line, severity, and actionable description
+3. Classify severity: critical, error, warning, info
+
+**Output format:**
+```
+REVIEW_START
+verdict: pass|revision|needs-human
+findings_count: N
+REVIEW_END
+
+For each finding:
+FINDING_START
+severity: critical|error|warning|info
+file: path/to/file
+line: N (if applicable)
+description: What and how to fix
+FINDING_END
+```

--- a/python/src/railclaw_pipeline/prompts/templates/wrench.j2
+++ b/python/src/railclaw_pipeline/prompts/templates/wrench.j2
@@ -1,0 +1,34 @@
+You are Wrench, the implementation agent for the coding factory.
+
+**Task:** Implement changes from the plan.
+
+**Issue:** #{{ issue_number }}
+**Plan:** {{ plan_path }}
+**Branch:** {{ branch }}
+
+**Instructions:**
+1. Read the PLAN.md file for detailed implementation phases
+2. Start from phase {{ start_phase }} (or the next uncompleted phase)
+3. For each phase:
+   - Implement all deliverables
+   - Add error handling and input validation
+   - Write/update tests
+   - Commit after each phase with format: `feat(phase N): description`
+4. Push after each commit
+
+**Constraints:**
+- Follow existing code patterns and conventions
+- No secrets or hardcoded values
+- All subprocess calls must use shell=False with list arguments
+- Atomic state writes where applicable
+- Python 3.11+ ARM64 compatible
+
+**Output format at end:**
+```
+RESULT_START
+status: success|failure
+phases_completed: [...]
+phases_skipped: [...]
+notes: ...
+RESULT_END
+```

--- a/python/src/railclaw_pipeline/prompts/templates/wrench_fix.j2
+++ b/python/src/railclaw_pipeline/prompts/templates/wrench_fix.j2
@@ -1,0 +1,30 @@
+You are Wrench, the fix agent for the coding factory.
+
+**Task:** Fix the following review/audit findings.
+
+**Issue:** #{{ issue_number }}
+**Branch:** {{ branch }}
+**Findings:**
+{{ findings_text }}
+
+**Instructions:**
+1. Read each finding verbatim — do not pre-validate or skip
+2. Fix all findings marked as completeness or hardening (mandatory)
+3. For polish findings, apply if reasonable
+4. Commit after fixes with: `fix(pipeline): address review findings round {{ round }}`
+5. Push changes
+
+**Rules:**
+- Every finding must be addressed — even if you think it's fine
+- Add a brief comment explaining the fix
+- If a finding is truly not applicable, explain why in the commit message
+
+**Output:**
+```
+RESULT_START
+status: success|failure
+findings_fixed: N
+findings_deferred: N
+notes: ...
+RESULT_END
+```

--- a/python/src/railclaw_pipeline/runner/__init__.py
+++ b/python/src/railclaw_pipeline/runner/__init__.py
@@ -1,0 +1,1 @@
+"""Agent runner subsystem."""

--- a/python/src/railclaw_pipeline/runner/agent.py
+++ b/python/src/railclaw_pipeline/runner/agent.py
@@ -1,0 +1,141 @@
+"""Agent configuration and execution for coding agents.
+
+Supports opencode, gemini, and other CLI-based coding agents.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from railclaw_pipeline.runner.subprocess_runner import (
+    AgentVerdict,
+    SubprocessResult,
+    parse_verdict,
+    run_subprocess,
+)
+
+
+@dataclass
+class AgentConfig:
+    """Configuration for a coding agent."""
+    name: str
+    model: str = ""
+    timeout: int = 600
+    command: str = "opencode"
+    args_template: list[str] = field(default_factory=lambda: ["run", "--dir", "{dir}", "{prompt}"])
+    workdir: Path | None = None
+
+    def build_args(self, workdir: Path, prompt: str) -> list[str]:
+        """Build command arguments with template substitution."""
+        args = []
+        for arg in self.args_template:
+            arg = arg.replace("{dir}", str(workdir))
+            arg = arg.replace("{prompt}", prompt)
+            arg = arg.replace("{model}", self.model)
+            args.append(arg)
+        return args
+
+
+@dataclass
+class AgentResult:
+    """Result from an agent execution."""
+    agent_name: str
+    verdict: AgentVerdict
+    stdout: str = ""
+    stderr: str = ""
+    duration: float = 0.0
+    returncode: int = 0
+    timed_out: bool = False
+    error: str | None = None
+    started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    finished_at: datetime | None = None
+
+    @property
+    def success(self) -> bool:
+        return self.verdict == AgentVerdict.PASS
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent": self.agent_name,
+            "verdict": self.verdict.value,
+            "duration": self.duration,
+            "returncode": self.returncode,
+            "timed_out": self.timed_out,
+            "error": self.error,
+            "stdout_preview": self.stdout[:1000] if self.stdout else None,
+        }
+
+
+class AgentRunner:
+    """Executes coding agents via subprocess."""
+
+    def __init__(
+        self,
+        agent: AgentConfig,
+        workdir: Path,
+        extra_env: dict[str, str] | None = None,
+    ) -> None:
+        self.agent = agent
+        self.workdir = workdir
+        self.extra_env = extra_env or {}
+        self._process = None
+
+    async def run(self, prompt: str, timeout: int | None = None) -> AgentResult:
+        """Execute the agent with the given prompt.
+
+        Args:
+            prompt: The prompt/task to send to the agent.
+            timeout: Override timeout in seconds.
+
+        Returns:
+            AgentResult with verdict and output.
+        """
+        effective_timeout = timeout or self.agent.timeout
+        workdir = self.agent.workdir or self.workdir
+        args = self.agent.build_args(workdir, prompt)
+
+        command = [self.agent.command] + args
+        started = datetime.now(timezone.utc)
+
+        try:
+            result: SubprocessResult = await run_subprocess(
+                command,
+                cwd=workdir,
+                env=self.extra_env,
+                timeout=effective_timeout,
+            )
+            finished = datetime.now(timezone.utc)
+            verdict = parse_verdict(result.stdout, result.stderr, result.returncode)
+
+            return AgentResult(
+                agent_name=self.agent.name,
+                verdict=verdict,
+                stdout=result.stdout,
+                stderr=result.stderr,
+                duration=result.duration,
+                returncode=result.returncode,
+                timed_out=result.timed_out,
+                started_at=started,
+                finished_at=finished,
+            )
+
+        except Exception as exc:
+            finished = datetime.now(timezone.utc)
+            return AgentResult(
+                agent_name=self.agent.name,
+                verdict=AgentVerdict.ERROR,
+                duration=(finished - started).total_seconds(),
+                error=str(exc),
+                started_at=started,
+                finished_at=finished,
+            )
+
+    async def kill(self) -> None:
+        """Kill a running agent process."""
+        if self._process:
+            try:
+                self._process.kill()
+            except ProcessLookupError:
+                pass
+            self._process = None

--- a/python/src/railclaw_pipeline/runner/agent.py
+++ b/python/src/railclaw_pipeline/runner/agent.py
@@ -26,12 +26,16 @@ class AgentConfig:
     args_template: list[str] = field(default_factory=lambda: ["run", "--dir", "{dir}", "{prompt}"])
     workdir: Path | None = None
 
-    def build_args(self, workdir: Path, prompt: str) -> list[str]:
-        """Build command arguments with template substitution."""
+    def build_args(self, workdir: Path) -> list[str]:
+        """Build command arguments with template substitution.
+
+        Prompt is passed via stdin to avoid ARG_MAX limits.
+        """
         args = []
         for arg in self.args_template:
+            if arg == "{prompt}":
+                continue
             arg = arg.replace("{dir}", str(workdir))
-            arg = arg.replace("{prompt}", prompt)
             arg = arg.replace("{model}", self.model)
             args.append(arg)
         return args
@@ -93,7 +97,7 @@ class AgentRunner:
         """
         effective_timeout = timeout or self.agent.timeout
         workdir = self.agent.workdir or self.workdir
-        args = self.agent.build_args(workdir, prompt)
+        args = self.agent.build_args(workdir)
 
         command = [self.agent.command] + args
         started = datetime.now(timezone.utc)
@@ -104,6 +108,7 @@ class AgentRunner:
                 cwd=workdir,
                 env=self.extra_env,
                 timeout=effective_timeout,
+                input_text=prompt,
             )
             finished = datetime.now(timezone.utc)
             verdict = parse_verdict(result.stdout, result.stderr, result.returncode)

--- a/python/src/railclaw_pipeline/runner/agent.py
+++ b/python/src/railclaw_pipeline/runner/agent.py
@@ -125,6 +125,8 @@ class AgentRunner:
                 finished_at=finished,
             )
 
+        except (SystemExit, KeyboardInterrupt):
+            raise
         except Exception as exc:
             finished = datetime.now(timezone.utc)
             return AgentResult(

--- a/python/src/railclaw_pipeline/runner/subprocess_runner.py
+++ b/python/src/railclaw_pipeline/runner/subprocess_runner.py
@@ -4,7 +4,6 @@ All subprocess calls use shell=False with list arguments only.
 """
 
 import asyncio
-import shlex
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import StrEnum

--- a/python/src/railclaw_pipeline/runner/subprocess_runner.py
+++ b/python/src/railclaw_pipeline/runner/subprocess_runner.py
@@ -1,0 +1,185 @@
+"""Async subprocess wrappers for spawning agent processes.
+
+All subprocess calls use shell=False with list arguments only.
+"""
+
+import asyncio
+import shlex
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+class SubprocessError(Exception):
+    """Raised when a subprocess fails."""
+
+    def __init__(self, message: str, returncode: int | None = None, stderr: str = "") -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+class AgentVerdict(StrEnum):
+    """Standardized verdict from agent execution."""
+    PASS = "pass"
+    REVISION = "revision"
+    NEEDS_HUMAN = "needs-human"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+
+
+@dataclass
+class SubprocessResult:
+    """Result from a subprocess execution."""
+    stdout: str = ""
+    stderr: str = ""
+    returncode: int = -1
+    duration: float = 0.0
+    timed_out: bool = False
+    killed: bool = False
+
+    @property
+    def success(self) -> bool:
+        return self.returncode == 0 and not self.timed_out
+
+
+def parse_verdict(stdout: str, stderr: str = "", returncode: int = 0) -> AgentVerdict:
+    """Parse agent verdict from stdout/stderr output.
+
+    Looks for RESULT_START/RESULT_END blocks or common verdict keywords.
+    """
+    # Check for structured result block
+    if "RESULT_START" in stdout:
+        for line in stdout.splitlines():
+            line = line.strip()
+            if line.startswith("status:"):
+                status = line.split(":", 1)[1].strip()
+                if status == "success":
+                    return AgentVerdict.PASS
+                elif status == "failure":
+                    return AgentVerdict.REVISION
+                elif status == "needs-human":
+                    return AgentVerdict.NEEDS_HUMAN
+                elif status == "timeout":
+                    return AgentVerdict.TIMEOUT
+                elif status == "error":
+                    return AgentVerdict.ERROR
+
+    # Fallback: keyword detection
+    lower = stdout.lower()
+    if any(kw in lower for kw in ["verdict: pass", "status: pass", "✓", "completed successfully"]):
+        return AgentVerdict.PASS
+    if any(kw in lower for kw in ["needs human", "blocked", "waiting for approval"]):
+        return AgentVerdict.NEEDS_HUMAN
+    if any(kw in lower for kw in ["revision needed", "changes requested", "fix required"]):
+        return AgentVerdict.REVISION
+
+    if returncode == 0:
+        return AgentVerdict.PASS
+    return AgentVerdict.ERROR
+
+
+async def run_subprocess(
+    command: list[str],
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+    input_text: str | None = None,
+) -> SubprocessResult:
+    """Run a subprocess with timeout and output capture.
+
+    Args:
+        command: Command and arguments as a list (shell=False).
+        cwd: Working directory.
+        env: Additional environment variables.
+        timeout: Maximum seconds to wait.
+        input_text: Text to send to stdin.
+
+    Returns:
+        SubprocessResult with stdout, stderr, returncode, duration.
+
+    Raises:
+        SubprocessError: On timeout or non-zero exit with context.
+    """
+    if not command:
+        raise SubprocessError("Empty command")
+
+    start = datetime.now(timezone.utc)
+    proc_env = None
+    if env:
+        import os
+        proc_env = {**os.environ, **env}
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.PIPE if input_text else asyncio.subprocess.DEVNULL,
+            cwd=str(cwd) if cwd else None,
+            env=proc_env,
+        )
+    except (OSError, FileNotFoundError) as exc:
+        raise SubprocessError(
+            f"Failed to start process: {command[0]!r}: {exc}"
+        ) from exc
+
+    try:
+        stdout_bytes, stderr_bytes = await asyncio.wait_for(
+            proc.communicate(input=input_text.encode() if input_text else None),
+            timeout=timeout,
+        )
+        elapsed = (datetime.now(timezone.utc) - start).total_seconds()
+        stdout_str = stdout_bytes.decode("utf-8", errors="replace")
+        stderr_str = stderr_bytes.decode("utf-8", errors="replace")
+
+        result = SubprocessResult(
+            stdout=stdout_str,
+            stderr=stderr_str,
+            returncode=proc.returncode or 0,
+            duration=elapsed,
+        )
+
+        if result.timed_out or not result.success:
+            raise SubprocessError(
+                f"Process exited with code {result.returncode}: {stderr_str[:500]}",
+                returncode=result.returncode,
+                stderr=stderr_str,
+            )
+
+        return result
+
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+        except ProcessLookupError:
+            pass
+        await proc.wait()
+        elapsed = (datetime.now(timezone.utc) - start).total_seconds()
+
+        raise SubprocessError(
+            f"Process timed out after {timeout}s: {command[0]!r}",
+            returncode=-1,
+        )
+
+
+async def run_subprocess_safe(
+    command: list[str],
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    timeout: float | None = None,
+    input_text: str | None = None,
+) -> SubprocessResult:
+    """Like run_subprocess but returns result instead of raising on failure."""
+    try:
+        return await run_subprocess(command, cwd, env, timeout, input_text)
+    except SubprocessError:
+        elapsed = 0.0
+        return SubprocessResult(
+            stderr=f"Process failed: {' '.join(command)}",
+            returncode=-1,
+            timed_out=timeout is not None,
+            duration=elapsed,
+        )

--- a/python/src/railclaw_pipeline/stages/__init__.py
+++ b/python/src/railclaw_pipeline/stages/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline stages."""

--- a/python/src/railclaw_pipeline/stages/cycle2_gemini.py
+++ b/python/src/railclaw_pipeline/stages/cycle2_gemini.py
@@ -1,0 +1,391 @@
+"""Cycle 2: Gemini review loop — poll reviews, extract findings, fix with Wrench."""
+
+import asyncio
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.github.pr import PrClient
+from railclaw_pipeline.github.review import (
+    ReviewResult,
+    extract_findings_from_comments,
+    extract_findings_from_reviews,
+    parse_details_blocks,
+    poll_reviews,
+)
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentConfig, AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+CYCLE2_POLL_INTERVAL = 60
+CYCLE2_MAX_WAIT = 900
+CYCLE2_SAFETY_CAP = 20
+
+
+async def run_gemini_loop(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    scope_runner: AgentRunner,
+) -> PipelineState:
+    """Cycle 2: Poll Gemini review, extract findings, fix with Wrench or Wrench Sr.
+
+    Flow per round:
+    1. Poll PR for Gemini reviews/comments
+    2. If clean (zero findings + formal review) -> set gemini_clean, return
+    3. If findings -> pass to Wrench (or Wrench Sr after round 3)
+    4. Wrench fixes -> push -> Scope re-reviews
+    5. Loop
+
+    Safety cap at 20 rounds. Non-convergence triggers Chris escalation.
+    """
+    if not state.pr_number:
+        raise RuntimeError("No PR number — cannot run Gemini review loop")
+
+    pr_client = PrClient(config.repo_path)
+    last_ts = state.gemini_tracking.get("last_gemini_timestamp")
+
+    emitter.emit("cycle2_poll_start", issue=state.issue_number, round=state.cycle.cycle2_round)
+
+    review_result = await _poll_with_timeout(
+        pr_client, state.pr_number, last_ts, config, emitter, state,
+    )
+
+    findings = _extract_gemini_findings(review_result)
+
+    if review_result.is_clean and review_result.has_formal_review:
+        state.cycle.gemini_clean = True
+        emitter.emit("cycle2_clean", issue=state.issue_number, round=state.cycle.cycle2_round)
+        state.findings["current"] = []
+        state.gemini_tracking["last_gemini_timestamp"] = review_result.last_processed_at
+        save_state(state, config.state_path)
+        return state
+
+    if not findings and not review_result.has_formal_review:
+        emitter.emit("cycle2_no_response", issue=state.issue_number, round=state.cycle.cycle2_round)
+        state.gemini_tracking["pending_poll"] = True
+        save_state(state, config.state_path)
+        return state
+
+    history = state.findings.get("history", [])
+    history.extend(state.findings.get("current", []))
+    state.findings = {"current": findings, "history": history}
+    state.gemini_tracking["last_gemini_timestamp"] = review_result.last_processed_at
+    save_state(state, config.state_path)
+
+    emitter.emit("cycle2_findings", issue=state.issue_number, round=state.cycle.cycle2_round, count=len(findings))
+
+    use_wrench_sr = state.cycle.cycle2_round >= config.escalation.get("wrenchSrAfterRound", 3) - 1
+    agent_name = "wrenchSr" if use_wrench_sr else "wrench"
+
+    if use_wrench_sr:
+        await _run_wrench_sr_fix(state, config, emitter, findings)
+    else:
+        wrench_config = _get_agent_config(config, "wrench")
+        wrench_runner = AgentRunner(wrench_config, config.repo_path)
+        await _run_wrench_fix(state, config, emitter, wrench_runner, findings)
+
+    context = {
+        "issue_number": state.issue_number,
+        "branch": state.branch or "",
+        "pr_number": state.pr_number,
+    }
+    prompt = render_template(config.factory_path, "scope_review.j2", context)
+    if not prompt:
+        prompt = _build_scope_re_review_prompt(state)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="scope", cli="opencode")
+    scope_result = await scope_runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="scope",
+        cli="opencode",
+        duration_s=scope_result.duration,
+        success=scope_result.success,
+    )
+
+    scope_findings = _parse_scope_findings(scope_result.stdout)
+    scope_verdict = _parse_verdict(scope_result.stdout)
+
+    state.cycle.scope_verdict = scope_verdict
+
+    if scope_verdict == "pass" and not scope_findings:
+        state.cycle.gemini_clean = True
+        state.findings["current"] = []
+        emitter.emit("cycle2_scope_clean", issue=state.issue_number, round=state.cycle.cycle2_round)
+    else:
+        state.findings["current"] = scope_findings
+        emitter.emit("cycle2_scope_findings", issue=state.issue_number, verdict=scope_verdict, count=len(scope_findings))
+
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+async def _poll_with_timeout(
+    pr_client: PrClient,
+    pr_number: int,
+    last_ts: str | None,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    state: PipelineState,
+) -> ReviewResult:
+    """Poll for Gemini review with timeout from config."""
+    poll_interval = config.timing.get("geminiPollInterval", CYCLE2_POLL_INTERVAL)
+    max_wait = CYCLE2_MAX_WAIT
+
+    elapsed = 0
+    while elapsed < max_wait:
+        result = await poll_reviews(pr_client, pr_number, last_ts)
+
+        gemini_reviews = [
+            r for r in result.raw_reviews
+            if r.get("author", "").lower().startswith("gemini")
+        ]
+        gemini_comments = [
+            c for c in result.raw_comments
+            if c.get("author", "").lower().startswith("gemini")
+        ]
+
+        if gemini_reviews or gemini_comments:
+            has_formal = any(
+                r.get("state") in ("APPROVED", "CHANGES_REQUESTED", "COMMENTED")
+                for r in gemini_reviews
+            )
+            if has_formal and result.is_clean:
+                return ReviewResult(
+                    findings=[],
+                    is_clean=True,
+                    has_formal_review=True,
+                    last_processed_at=datetime.now(timezone.utc).isoformat(),
+                )
+            return result
+
+        emitter.emit("cycle2_poll_wait", issue=state.issue_number, elapsed=elapsed)
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+
+    emitter.emit("cycle2_poll_timeout", issue=state.issue_number)
+    return ReviewResult(
+        findings=[],
+        is_clean=True,
+        has_formal_review=False,
+        last_processed_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def _extract_gemini_findings(review_result: ReviewResult) -> list[dict[str, Any]]:
+    """Extract findings from review result, separating Gemini from other sources."""
+    findings: list[dict[str, Any]] = []
+    for f in review_result.raw_reviews:
+        body = f.get("body", "")
+        if not body:
+            continue
+        author = f.get("author", "")
+        blocks = parse_details_blocks(body)
+        for block in blocks:
+            findings.append({
+                "category": "gemini",
+                "description": block[:500],
+                "raw_text": block,
+                "source": "gemini_review",
+                "author": author,
+            })
+        if not blocks and f.get("state") == "CHANGES_REQUESTED":
+            findings.append({
+                "category": "gemini",
+                "description": body[:500],
+                "raw_text": body,
+                "source": "gemini_review",
+                "author": author,
+            })
+
+    for c in review_result.raw_comments:
+        body = c.get("body", "")
+        if not body:
+            continue
+        author = c.get("author", "")
+        findings.append({
+            "category": "gemini-inline",
+            "description": body[:500],
+            "raw_text": body,
+            "source": "gemini_comment",
+            "author": author,
+        })
+
+    return findings
+
+
+async def _run_wrench_fix(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    runner: AgentRunner,
+    findings: list[dict[str, Any]],
+) -> None:
+    """Run Wrench to fix Gemini findings."""
+    repo = config.repo_path
+    git_ops = GitOperations(repo)
+    await git_ops.reset_hard("HEAD")
+    await git_ops.clean()
+
+    findings_text = _format_findings(findings)
+    context = {
+        "issue_number": state.issue_number,
+        "branch": state.branch or "",
+        "findings_text": findings_text,
+        "round": state.cycle.cycle2_round + 1,
+        "source": "gemini",
+    }
+
+    prompt = render_template(config.factory_path, "wrench_fix.j2", context)
+    if not prompt:
+        prompt = _build_fix_prompt(state, findings_text, "Wrench")
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="wrench", cli="opencode")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="wrench",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    if not result.success:
+        raise RuntimeError(f"Cycle 2 Wrench fix failed: {result.error or result.stderr[:500]}")
+
+
+async def _run_wrench_sr_fix(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    findings: list[dict[str, Any]],
+) -> None:
+    """Run Wrench Sr (Gemini CLI) for complex fixes."""
+    wrench_sr_config = _get_agent_config(config, "wrenchSr")
+    runner = AgentRunner(wrench_sr_config, config.repo_path)
+
+    findings_text = _format_findings(findings)
+    context = {
+        "issue_number": state.issue_number,
+        "branch": state.branch or "",
+        "findings_text": findings_text,
+        "round": state.cycle.cycle2_round + 1,
+        "source": "gemini",
+    }
+
+    prompt = render_template(config.factory_path, "wrench_fix.j2", context)
+    if not prompt:
+        prompt = _build_fix_prompt(state, findings_text, "Wrench Sr")
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="wrenchSr", cli="gemini")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="wrenchSr",
+        cli="gemini",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    if not result.success:
+        raise RuntimeError(f"Cycle 2 Wrench Sr fix failed: {result.error or result.stderr[:500]}")
+
+
+def _format_findings(findings: list[dict[str, Any]]) -> str:
+    lines = []
+    for i, f in enumerate(findings, 1):
+        source = f.get("source", "unknown")
+        desc = f.get("description", f.get("raw_text", str(f)))
+        lines.append(f"{i}. [{source}] {desc}")
+    return "\n".join(lines)
+
+
+def _build_fix_prompt(state: PipelineState, findings_text: str, agent: str) -> str:
+    return (
+        f"You are {agent}, the fix agent.\n\n"
+        f"Fix the following Gemini review findings for issue #{state.issue_number}.\n"
+        f"Branch: {state.branch}\n\n"
+        f"Findings:\n{findings_text}\n\n"
+        f"All completeness and hardening findings are mandatory.\n"
+        f"Commit with: fix(cycle2): address Gemini review findings\n\n"
+        f"Before starting, read factory/AGENT-RULES.md.\n\n"
+        f"RESULT_START\nstatus: success\nRESULT_END"
+    )
+
+
+def _build_scope_re_review_prompt(state: PipelineState) -> str:
+    pr_info = f"PR: #{state.pr_number}\n" if state.pr_number else ""
+    return (
+        f"You are Scope, the code review agent.\n\n"
+        f"Re-review the code after Gemini fixes for issue #{state.issue_number}.\n"
+        f"Branch: {state.branch}\n"
+        f"{pr_info}\n"
+        f"Provide a verdict (pass/revision) and list any remaining findings.\n\n"
+        f"Before starting, read factory/AGENT-RULES.md.\n\n"
+        f"RESULT_START\nstatus: success\nRESULT_END"
+    )
+
+
+def _parse_scope_findings(output: str) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    pattern = re.compile(r"FINDING_START\s*\n(.*?)\nFINDING_END", re.DOTALL)
+    for match in pattern.finditer(output):
+        block = match.group(1).strip()
+        finding: dict[str, Any] = {}
+        for line in block.splitlines():
+            line = line.strip()
+            if ":" in line:
+                key, _, value = line.partition(":")
+                finding[key.strip()] = value.strip()
+        if finding:
+            findings.append(finding)
+    return findings
+
+
+def _parse_verdict(output: str) -> str:
+    match = re.search(r"verdict:\s*(pass|revision|needs-human)", output, re.IGNORECASE)
+    if match:
+        return match.group(1).lower()
+    if "RESULT_START" in output and "status: success" in output:
+        return "pass"
+    return "revision"
+
+
+def _get_agent_config(config: PipelineConfig, agent_name: str) -> AgentConfig:
+    agent_cfg = config.agents.get(agent_name, {})
+    model = agent_cfg.get("model", "")
+    timeout = agent_cfg.get("timeout", 600)
+
+    workdir = config.repo_path
+    command = "opencode"
+    args_template = ["run", "--dir", str(workdir), "--timeout", str(timeout), "{prompt}"]
+
+    if agent_name in ("wrenchSr", "scout"):
+        command = "gemini"
+        args_template = ["--model", model, "{prompt}"]
+    elif agent_name in ("blueprint", "wrench", "scope", "beaker", "quill"):
+        env_dir = config.factory_path / "envs" / agent_name
+        if env_dir.exists():
+            workdir = env_dir
+        args_template = ["run", "--dir", str(workdir), "--timeout", str(timeout), "{prompt}"]
+
+    return AgentConfig(
+        name=agent_name,
+        model=model,
+        timeout=timeout,
+        command=command,
+        args_template=args_template,
+        workdir=workdir,
+    )

--- a/python/src/railclaw_pipeline/stages/cycle2_gemini.py
+++ b/python/src/railclaw_pipeline/stages/cycle2_gemini.py
@@ -194,8 +194,8 @@ def _extract_gemini_findings(review_result: ReviewResult) -> list[dict[str, Any]
         for block in blocks:
             findings.append({
                 "category": "gemini",
-                "description": block[:500],
-                "raw_text": block,
+                "description": block.description[:500],
+                "raw_text": block.raw_text,
                 "source": "gemini_review",
                 "author": author,
             })

--- a/python/src/railclaw_pipeline/stages/stage0_preflight.py
+++ b/python/src/railclaw_pipeline/stages/stage0_preflight.py
@@ -1,0 +1,68 @@
+"""Stage 0: Preflight — verify environment readiness before pipeline."""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+class PreflightError(Exception):
+    """Raised when preflight checks fail."""
+    pass
+
+
+async def run_preflight(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+) -> PipelineState:
+    """Stage 0: Verify environment before starting pipeline.
+
+    Checks:
+    1. On main branch with clean working tree
+    2. Repo is up to date with remote
+    3. factory/ directory exists
+    4. Required tools (gh, git) are available
+    """
+    repo = config.repo_path
+
+    if not repo.exists():
+        raise PreflightError(f"Repo path does not exist: {repo}")
+
+    git_ops = GitOperations(repo)
+
+    branch = await git_ops.current_branch()
+    if branch != "main":
+        raise PreflightError(f"Not on main branch (current: {branch})")
+
+    if await git_ops.is_dirty():
+        raise PreflightError("Working tree not clean — commit or stash changes first")
+
+    await git_ops.fetch("origin")
+    await git_ops.pull("origin", "main")
+
+    if not config.factory_path.exists():
+        raise PreflightError(f"factory/ directory not found at {config.factory_path}")
+
+    for tool_name in ("gh", "git"):
+        proc = await asyncio.create_subprocess_exec(
+            "which", tool_name,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await proc.communicate()
+        if proc.returncode != 0:
+            raise PreflightError(f"Required tool not found: {tool_name}")
+
+    emitter.emit("preflight_pass", issue=state.issue_number)
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state

--- a/python/src/railclaw_pipeline/stages/stage10_qa.py
+++ b/python/src/railclaw_pipeline/stages/stage10_qa.py
@@ -1,0 +1,173 @@
+"""Stage 10: Beaker QA sweep — run QA agent, file critical issues."""
+
+import logging
+from datetime import datetime, timezone
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.gh import GhClient
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+async def run_qa(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    runner: AgentRunner,
+) -> PipelineState:
+    """Stage 10: Run Beaker QA on merged main.
+
+    Runs Beaker QA sweep, files critical issues as GitHub issues.
+    Does NOT block deployment per pipeline rules.
+    """
+    emitter.emit("qa_start", issue=state.issue_number, pr=state.pr_number)
+
+    context = {
+        "issue_number": state.issue_number,
+        "branch": state.branch or "",
+        "pr_number": state.pr_number or "",
+        "repo_path": str(config.repo_path),
+    }
+
+    prompt = render_template(config.factory_path, "beaker_qa.j2", context)
+    if not prompt:
+        prompt = _build_qa_prompt(state)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="beaker", cli="opencode")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="beaker",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    qa_findings = _parse_findings(result.stdout)
+
+    if not result.success:
+        logger.warning(
+            "Beaker QA had issues for #%d (non-blocking): %s",
+            state.issue_number,
+            result.error or result.stderr[:300],
+        )
+        emitter.emit("qa_warning", issue=state.issue_number, error=result.error or "non-zero exit")
+
+    critical_filed = []
+    for finding in qa_findings:
+        severity = finding.get("severity", "").upper()
+        if severity in ("HIGH", "CRITICAL") and finding.get("status") != "fixed":
+            filed_number = await _file_critical_issue(
+                config, state, finding,
+            )
+            if filed_number:
+                critical_filed.append(filed_number)
+                emitter.emit(
+                    "critical_issue_filed",
+                    issue=state.issue_number,
+                    filed_issue=filed_number,
+                    severity=severity,
+                    title=finding.get("title", finding.get("description", "")[:80]),
+                )
+
+    history = state.findings.get("history", [])
+    history.extend(qa_findings)
+    state.findings = {
+        "current": state.findings.get("current", []),
+        "history": history,
+        "qa_critical_filed": critical_filed,
+    }
+
+    emitter.emit(
+        "qa_complete",
+        issue=state.issue_number,
+        findings_count=len(qa_findings),
+        critical_filed=len(critical_filed),
+    )
+
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+async def _file_critical_issue(
+    config: PipelineConfig,
+    state: PipelineState,
+    finding: dict,
+) -> int | None:
+    """File a critical QA finding as a GitHub issue. Returns issue number or None."""
+    gh = GhClient(config.repo_path)
+    title = f"[Auto-filed from QA] {finding.get('title', finding.get('description', 'Untitled')[:80])}"
+    body = (
+        f"**Source:** Beaker QA run for PR #{state.pr_number}\n"
+        f"**Severity:** {finding.get('severity', 'UNKNOWN')}\n"
+        f"**Description:** {finding.get('description', 'No description')}\n"
+        f"\nAuto-filed by orchestrator during Stage 10 QA."
+    )
+    try:
+        result = await gh.issue_create(title, body, labels=["bug", "qa"])
+        url = result.get("url", "")
+        if url:
+            import re
+            match = re.search(r"/issues/(\d+)", url)
+            if match:
+                return int(match.group(1))
+    except Exception:
+        logger.warning("Failed to file critical QA issue", exc_info=True)
+    return None
+
+
+def _parse_findings(stdout: str) -> list[dict]:
+    """Parse structured findings from Beaker output."""
+    findings = []
+    in_block = False
+    current = {}
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if line == "FINDING_START":
+            in_block = True
+            current = {}
+            continue
+        if line == "FINDING_END":
+            in_block = False
+            if current:
+                findings.append(current)
+            current = {}
+            continue
+        if in_block and ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip().lower().replace(" ", "_")
+            current[key] = value.strip()
+
+    return findings
+
+
+def _build_qa_prompt(state: PipelineState) -> str:
+    return (
+        "You are Beaker, the QA agent.\n\n"
+        f"Run a QA sweep on the merged code for issue #{state.issue_number}.\n"
+        f"PR: #{state.pr_number}\n"
+        f"Branch: {state.branch}\n\n"
+        "Check:\n"
+        "- PLAN.md completeness — verify all phases implemented\n"
+        "- Build and lint pass\n"
+        "- No obvious regressions\n"
+        "- No missing error handling\n\n"
+        "Report findings using:\n"
+        "FINDING_START\n"
+        "severity: HIGH|MEDIUM|LOW\n"
+        "title: <title>\n"
+        "description: <description>\n"
+        "category: completeness|hardening|polish\n"
+        "FINDING_END\n\n"
+        "Before starting, read factory/AGENT-RULES.md.\n\n"
+        "RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/stages/stage11_hotfix.py
+++ b/python/src/railclaw_pipeline/stages/stage11_hotfix.py
@@ -121,7 +121,7 @@ async def run_hotfix(
         base="main",
         head=fix_branch,
     )
-    state.pr_number = pr_result.get("number")
+    state.pr_number = pr_result.get("pr_number")
 
     review_context = {
         "issue_number": state.issue_number,

--- a/python/src/railclaw_pipeline/stages/stage11_hotfix.py
+++ b/python/src/railclaw_pipeline/stages/stage11_hotfix.py
@@ -1,0 +1,218 @@
+"""Stage 11: Hotfix — post-hoc review for direct-to-main emergency fixes.
+
+Hotfixes bypass the standard pipeline (skip stages 1-2.5) but ALWAYS get post-hoc review.
+Findings → new branch → Wrench fixes → PR → Scope re-review → approval → merge.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.github.gh import GhClient
+from railclaw_pipeline.github.pr import PrClient
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+async def run_hotfix(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    wrench_runner: AgentRunner,
+    scope_runner: AgentRunner,
+) -> PipelineState:
+    """Stage 11: Post-hoc review for a direct-to-main hotfix.
+
+    Flow:
+    1. Get hotfix diff (git diff main~1 main)
+    2. Scope reviews the diff
+    3. If findings → new branch → Wrench fixes → PR → Scope re-review
+    4. File regression issues if needed
+    5. If no findings → proceed
+    """
+    git_ops = GitOperations(config.repo_path)
+    pr_client = PrClient(config.repo_path)
+    gh_client = GhClient(config.repo_path)
+
+    emitter.emit("hotfix_start", issue=state.issue_number)
+
+    diff = await git_ops._git("diff", "main~1", "main")
+
+    context = {
+        "issue_number": state.issue_number,
+        "diff": diff[:8000],
+        "repo_path": str(config.repo_path),
+    }
+
+    prompt = render_template(config.factory_path, "scope_audit.j2", context)
+    if not prompt:
+        prompt = _build_hotfix_review_prompt(state, diff)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="scope", cli="opencode")
+    result = await scope_runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="scope",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    findings = _parse_hotfix_findings(result.stdout)
+
+    if not findings:
+        emitter.emit("hotfix_clean", issue=state.issue_number)
+        if state.timestamps:
+            state.timestamps.last_updated = datetime.now(timezone.utc)
+        save_state(state, config.state_path)
+        return state
+
+    emitter.emit("hotfix_findings", issue=state.issue_number, count=len(findings))
+
+    fix_branch = f"hotfix/{state.issue_number}-post-hoc-fixes"
+    await git_ops.checkout_new(fix_branch, "main")
+
+    findings_text = "\n".join(
+        f"- [{f.get('severity', 'info').upper()}] {f.get('description', str(f))}"
+        for f in findings
+    )
+
+    fix_context = {
+        "issue_number": state.issue_number,
+        "findings_text": findings_text,
+        "is_hotfix": True,
+    }
+    fix_prompt = render_template(config.factory_path, "wrench_fix.j2", fix_context)
+    if not fix_prompt:
+        fix_prompt = _build_hotfix_fix_prompt(state, findings_text)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="wrench", cli="opencode")
+    fix_result = await wrench_runner.run(fix_prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="wrench",
+        cli="opencode",
+        duration_s=fix_result.duration,
+        success=fix_result.success,
+    )
+
+    if not fix_result.success:
+        raise RuntimeError(
+            f"Hotfix Wrench fix failed: {fix_result.error or fix_result.stderr[:500]}"
+        )
+
+    await git_ops.push("origin", fix_branch, set_upstream=True)
+
+    pr_body = (
+        f"Post-hoc review fixes for hotfix on issue #{state.issue_number}\n\n"
+        f"Findings addressed:\n{findings_text}"
+    )
+    pr_result = await pr_client.create(
+        title=f"Hotfix: #{state.issue_number} post-hoc fixes",
+        body=pr_body,
+        base="main",
+        head=fix_branch,
+    )
+    state.pr_number = pr_result.get("number")
+
+    review_context = {
+        "issue_number": state.issue_number,
+        "pr_number": state.pr_number or "",
+        "repo_path": str(config.repo_path),
+    }
+    review_prompt = render_template(config.factory_path, "scope_review.j2", review_context)
+    if not review_prompt:
+        review_prompt = f"Review PR #{state.pr_number} for hotfix on issue #{state.issue_number}."
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="scope", cli="opencode")
+    review_result = await scope_runner.run(review_prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="scope",
+        cli="opencode",
+        duration_s=review_result.duration,
+        success=review_result.success,
+    )
+
+    regression_findings = _parse_hotfix_findings(review_result.stdout)
+    for finding in regression_findings:
+        severity = finding.get("severity", "").upper()
+        if severity in ("HIGH", "CRITICAL"):
+            try:
+                await gh_client.issue_create(
+                    title=f"Regression from hotfix on issue #{state.issue_number}",
+                    body=f"- {finding.get('description', str(finding))}",
+                    labels=["bug", "regression"],
+                )
+                emitter.emit("regression_filed", issue=state.issue_number)
+            except Exception:
+                logger.warning("Failed to file regression issue", exc_info=True)
+
+    history = state.findings.get("history", [])
+    history.extend(findings)
+    state.findings = {"current": regression_findings, "history": history}
+
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+def _parse_hotfix_findings(stdout: str) -> list[dict]:
+    """Parse findings from hotfix review output."""
+    findings = []
+    in_block = False
+    current = {}
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if line == "FINDING_START":
+            in_block = True
+            current = {}
+            continue
+        if line == "FINDING_END":
+            in_block = False
+            if current:
+                findings.append(current)
+            current = {}
+            continue
+        if in_block and ":" in line:
+            key, _, value = line.partition(":")
+            key = key.strip().lower().replace(" ", "_")
+            current[key] = value.strip()
+
+    return findings
+
+
+def _build_hotfix_review_prompt(state: PipelineState, diff: str) -> str:
+    return (
+        "You are Scope, the review agent.\n\n"
+        f"Review this hotfix diff for issue #{state.issue_number}.\n\n"
+        f"Diff:\n{diff[:6000]}\n\n"
+        "Report findings using:\n"
+        "FINDING_START\n"
+        "severity: HIGH|MEDIUM|LOW\n"
+        "description: <description>\n"
+        "FINDING_END\n\n"
+        "RESULT_START\nstatus: success\nRESULT_END"
+    )
+
+
+def _build_hotfix_fix_prompt(state: PipelineState, findings_text: str) -> str:
+    return (
+        "You are Wrench, the fix agent.\n\n"
+        f"Fix these hotfix review findings for issue #{state.issue_number}.\n\n"
+        f"Findings:\n{findings_text}\n\n"
+        "Commit with: fix(hotfix): address post-hoc review findings\n\n"
+        "Before starting, read factory/AGENT-RULES.md.\n\n"
+        "RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/stages/stage12_lessons.py
+++ b/python/src/railclaw_pipeline/stages/stage12_lessons.py
@@ -1,0 +1,180 @@
+"""Stage 12: Lessons learned — generate entry, archive checkpoint.
+
+Runs in the finally block of every pipeline run (success or failure).
+"""
+
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.state.models import PipelineState, PipelineStatus
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+LESSONS_TEMPLATE = """## Issue #{issue_number} — {timestamp}
+
+**Result:** {result}
+**Duration:** {duration}
+**Branch:** {branch}
+**PR:** #{pr_number}
+
+### What Worked
+- (Fill in during review)
+
+### What Didn't
+- (Fill in during review)
+
+### Actionable Improvements
+- (Fill in during review)
+
+### Process Changes (if any)
+- (Fill in during review)
+
+### Deferred Items Audit
+Verify every deferred item has a corresponding GitHub issue:
+- (List each deferred item with its GitHub issue number)
+
+### Process Violations
+Any violations caught during this run (even if functionally correct):
+- (List violations by stage, or "No process violations detected.")
+
+---
+
+"""
+
+
+async def run_lessons(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+) -> PipelineState:
+    """Stage 12: Write lessons learned entry and archive checkpoint.
+
+    This is called from the pipeline's finally block, so it must not raise.
+    """
+    lessons_path = config.factory_path / "lessons-learned.md"
+
+    duration = _compute_duration(state)
+    result = state.status.value if state.status else "unknown"
+
+    entry = LESSONS_TEMPLATE.format(
+        issue_number=state.issue_number,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        result=result,
+        duration=duration,
+        branch=state.branch or "N/A",
+        pr_number=state.pr_number or "N/A",
+    )
+
+    entry += _append_findings_summary(state)
+    entry += _append_error_summary(state)
+
+    lessons_path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_append(lessons_path, entry)
+
+    emitter.emit(
+        "lessons_written",
+        issue=state.issue_number,
+        payload={"path": str(lessons_path), "result": result},
+    )
+
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+def _compute_duration(state: PipelineState) -> str:
+    """Compute human-readable duration from timestamps."""
+    if not state.timestamps:
+        return "N/A"
+
+    start = state.timestamps.started
+    end = state.timestamps.last_updated
+    delta = end - start
+    total_seconds = int(delta.total_seconds())
+
+    if total_seconds < 60:
+        return f"{total_seconds}s"
+    elif total_seconds < 3600:
+        minutes = total_seconds // 60
+        seconds = total_seconds % 60
+        return f"{minutes}m {seconds}s"
+    else:
+        hours = total_seconds // 3600
+        minutes = (total_seconds % 3600) // 60
+        return f"{hours}h {minutes}m"
+
+
+def _append_findings_summary(state: PipelineState) -> str:
+    """Append findings summary to the lessons entry."""
+    current = state.findings.get("current", [])
+    history = state.findings.get("history", [])
+
+    if not current and not history:
+        return ""
+
+    lines = ["### Findings Summary\n"]
+    if history:
+        lines.append(f"- Resolved findings: {len(history)}")
+    if current:
+        lines.append(f"- Open findings: {len(current)}")
+        for i, f in enumerate(current[:10], 1):
+            desc = f.get("description", f.get("raw_text", str(f)))[:100]
+            sev = f.get("severity", "info")
+            lines.append(f"  {i}. [{sev.upper()}] {desc}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _append_error_summary(state: PipelineState) -> str:
+    """Append error summary to the lessons entry."""
+    if not state.error:
+        return ""
+
+    lines = [
+        "### Error Details\n",
+        f"- **Category:** {state.error.get('category', 'unknown')}",
+        f"- **Message:** {state.error.get('message', 'N/A')[:200]}",
+        f"- **Stage:** {state.error.get('stage', state.stage.value)}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _atomic_append(path: Path, data: str) -> None:
+    """Safely append data to a file using atomic write pattern."""
+    try:
+        if path.exists():
+            existing = path.read_text(encoding="utf-8")
+        else:
+            existing = ""
+
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(path.parent), suffix=".tmp", prefix="lessons_"
+        )
+        try:
+            os.write(fd, (existing + data).encode("utf-8"))
+            os.fsync(fd)
+            os.close(fd)
+            os.replace(tmp_path, str(path))
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except Exception:
+        logger.warning("Failed to write lessons learned", exc_info=True)
+        try:
+            with open(path, "a") as f:
+                f.write(data)
+        except Exception:
+            logger.error("Fallback lessons write also failed", exc_info=True)

--- a/python/src/railclaw_pipeline/stages/stage1_blueprint.py
+++ b/python/src/railclaw_pipeline/stages/stage1_blueprint.py
@@ -1,0 +1,99 @@
+"""Stage 1: Blueprint — planning agent produces PLAN.md."""
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.gh import GhClient
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentConfig, AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+async def run_blueprint(
+    state: PipelineState,
+    config: PipelineConfig,
+    runner: AgentRunner,
+    emitter: EventEmitter,
+) -> PipelineState:
+    """Stage 1: Fetch issue, invoke Blueprint agent, write PLAN.md.
+
+    Blueprint reads the issue, analyzes the codebase, and writes
+    a detailed implementation plan to PLAN.md in the repo root.
+    """
+    gh = GhClient(config.repo_path)
+    issue_data = await gh.issue_view(state.issue_number)
+
+    issue_title = issue_data.get("title", "")
+    issue_body = issue_data.get("body", "")
+
+    branch_name = f"feat/issue-{state.issue_number}-{_slugify(issue_title)}"
+    state.branch = branch_name
+    state.plan_path = str(config.repo_path / "PLAN.md")
+
+    context = {
+        "issue_number": state.issue_number,
+        "issue_title": issue_title,
+        "issue_body": issue_body,
+        "repo_name": config.repo_path.name,
+        "branch": branch_name,
+    }
+
+    prompt = render_template(config.factory_path, "blueprint.j2", context)
+    if not prompt:
+        prompt = _build_blueprint_prompt(state, issue_title, issue_body, branch_name, config)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="blueprint", cli="opencode")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="blueprint",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    plan_path = Path(state.plan_path) if state.plan_path else config.repo_path / "PLAN.md"
+    if not plan_path.exists():
+        raise RuntimeError(f"Blueprint did not produce PLAN.md at {plan_path}")
+
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a branch-safe slug."""
+    import re
+    slug = text.lower().strip()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    slug = re.sub(r"[\s_]+", "-", slug)
+    slug = slug.strip("-")
+    return slug[:50]
+
+
+def _build_blueprint_prompt(
+    state: PipelineState,
+    issue_title: str,
+    issue_body: str,
+    branch: str,
+    config: PipelineConfig,
+) -> str:
+    """Fallback prompt when template not available."""
+    return (
+        f"You are Blueprint, the planning agent.\n\n"
+        f"Create a detailed PLAN.md for issue #{state.issue_number}: {issue_title}\n\n"
+        f"Issue body:\n{issue_body}\n\n"
+        f"Repository: {config.repo_path.name}\n"
+        f"Branch: {branch}\n\n"
+        f"Write the plan to PLAN.md in the repo root.\n"
+        f"Include phases with deliverables, tests, and dependencies.\n\n"
+        f"RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/stages/stage1_blueprint.py
+++ b/python/src/railclaw_pipeline/stages/stage1_blueprint.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from railclaw_pipeline.config import PipelineConfig
 from railclaw_pipeline.events.emitter import EventEmitter
 from railclaw_pipeline.github.gh import GhClient
+from railclaw_pipeline.github.git import sanitize_branch_name
 from railclaw_pipeline.prompts.loader import render_template
 from railclaw_pipeline.runner.agent import AgentConfig, AgentRunner
 from railclaw_pipeline.state.models import PipelineState
@@ -33,7 +34,9 @@ async def run_blueprint(
     issue_title = issue_data.get("title", "")
     issue_body = issue_data.get("body", "")
 
-    branch_name = f"feat/issue-{state.issue_number}-{_slugify(issue_title)}"
+    branch_name = sanitize_branch_name(
+        f"feat/issue-{state.issue_number}-{_slugify(issue_title)}"
+    )
     state.branch = branch_name
     state.plan_path = str(config.repo_path / "PLAN.md")
 

--- a/python/src/railclaw_pipeline/stages/stage1_blueprint.py
+++ b/python/src/railclaw_pipeline/stages/stage1_blueprint.py
@@ -76,6 +76,7 @@ def _slugify(text: str) -> str:
     slug = re.sub(r"[^\w\s-]", "", slug)
     slug = re.sub(r"[\s_]+", "-", slug)
     slug = slug.strip("-")
+    slug = slug[:200]
     return slug[:50]
 
 

--- a/python/src/railclaw_pipeline/stages/stage2_5_pr.py
+++ b/python/src/railclaw_pipeline/stages/stage2_5_pr.py
@@ -1,0 +1,71 @@
+"""Stage 2.5: Create PR — uses gh CLI to create a pull request."""
+
+import logging
+from datetime import datetime, timezone
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.pr import PrClient
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+async def run_create_pr(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+) -> PipelineState:
+    """Stage 2.5: Create PR via gh CLI.
+
+    Idempotent: if PR already exists for this branch, skip creation.
+    """
+    if not state.branch:
+        raise RuntimeError("No branch set — cannot create PR")
+
+    pr_client = PrClient(config.repo_path)
+
+    existing = await pr_client.find_by_head(state.branch)
+    if existing:
+        state.pr_number = existing.get("number")
+        emitter.emit(
+            "pr_exists",
+            issue=state.issue_number,
+            pr=state.pr_number,
+            message=f"PR already exists: #{state.pr_number}",
+        )
+        save_state(state, config.state_path)
+        return state
+
+    title = f"Issue #{state.issue_number}: {state.branch.replace('feat/issue-', '').replace('-', ' ')}"
+    body = f"Closes #{state.issue_number}\n\nAutomated pipeline implementation."
+
+    result = await pr_client.create(
+        title=title,
+        body=body,
+        base="main",
+        head=state.branch,
+    )
+
+    state.pr_number = result.get("pr_number")
+    if not state.pr_number:
+        url = result.get("url", "")
+        if "/pull/" in url:
+            try:
+                state.pr_number = int(url.rstrip("/").split("/")[-1])
+            except (ValueError, IndexError):
+                raise RuntimeError(f"Failed to parse PR number from URL: {url}")
+        else:
+            raise RuntimeError(f"PR creation returned no number: {result}")
+
+    emitter.emit(
+        "pr_created",
+        issue=state.issue_number,
+        pr=state.pr_number,
+        branch=state.branch,
+    )
+
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state

--- a/python/src/railclaw_pipeline/stages/stage2_wrench.py
+++ b/python/src/railclaw_pipeline/stages/stage2_wrench.py
@@ -52,7 +52,7 @@ async def run_wrench(
         "plan_path": str(plan_path),
     }
 
-    prompt = render_template(config.factory_path, "wrench-implement.j2", context)
+    prompt = render_template(config.factory_path, "wrench.j2", context)
     if not prompt:
         prompt = _build_wrench_prompt(state, plan_content, config)
 

--- a/python/src/railclaw_pipeline/stages/stage2_wrench.py
+++ b/python/src/railclaw_pipeline/stages/stage2_wrench.py
@@ -1,0 +1,110 @@
+"""Stage 2: Wrench — implementation agent executes PLAN.md phases."""
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentConfig, AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+async def run_wrench(
+    state: PipelineState,
+    config: PipelineConfig,
+    runner: AgentRunner,
+    emitter: EventEmitter,
+) -> PipelineState:
+    """Stage 2: Wrench implements the plan phase by phase.
+
+    On resume, resets working tree to discard partial work from a crashed run,
+    then re-executes the full Wrench prompt against a clean state.
+    """
+    repo = config.repo_path
+    git_ops = GitOperations(repo)
+
+    if not state.branch:
+        raise RuntimeError("No branch set — Blueprint must run first")
+
+    await _ensure_branch(git_ops, state.branch)
+
+    await git_ops.reset_hard("HEAD")
+    await git_ops.clean()
+
+    plan_path = Path(state.plan_path) if state.plan_path else repo / "PLAN.md"
+    plan_content = ""
+    if plan_path.exists():
+        plan_content = plan_path.read_text(encoding="utf-8")
+
+    if not plan_content:
+        raise RuntimeError(f"PLAN.md not found or empty at {plan_path}")
+
+    context = {
+        "issue_number": state.issue_number,
+        "repo_path": str(repo),
+        "branch": state.branch,
+        "plan_path": str(plan_path),
+    }
+
+    prompt = render_template(config.factory_path, "wrench-implement.j2", context)
+    if not prompt:
+        prompt = _build_wrench_prompt(state, plan_content, config)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="wrench", cli="opencode")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="wrench",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    if not result.success:
+        raise RuntimeError(
+            f"Wrench implementation failed: {result.error or result.stderr[:500]}"
+        )
+
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+async def _ensure_branch(git_ops: GitOperations, branch: str) -> None:
+    """Create feature branch from main if it doesn't exist."""
+    current = await git_ops.current_branch()
+    if current == branch:
+        return
+
+    exists = await git_ops.branch_exists(branch)
+    if exists:
+        await git_ops.checkout(branch)
+    else:
+        await git_ops.checkout_new(branch, "main")
+
+
+def _build_wrench_prompt(
+    state: PipelineState,
+    plan_content: str,
+    config: PipelineConfig,
+) -> str:
+    """Fallback prompt when Jinja2 template is not available."""
+    return (
+        f"You are Wrench, the implementation agent.\n\n"
+        f"Implement the following plan for issue #{state.issue_number}.\n\n"
+        f"Branch: {state.branch}\n"
+        f"Repository: {config.repo_path}\n\n"
+        f"PLAN.md:\n{plan_content}\n\n"
+        f"Implement ALL phases from the plan. Commit after each phase.\n"
+        f"Follow all conventions in the existing codebase.\n"
+        f"Write tests for all new code.\n\n"
+        f"Before starting, read factory/AGENT-RULES.md and follow all rules defined there.\n\n"
+        f"RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/stages/stage3_5_fix.py
+++ b/python/src/railclaw_pipeline/stages/stage3_5_fix.py
@@ -1,0 +1,90 @@
+"""Stage 3.5: Audit fix — Wrench fixes all audit findings verbatim."""
+
+import logging
+from datetime import datetime, timezone
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+async def run_audit_fix(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    runner: AgentRunner,
+) -> PipelineState:
+    """Stage 3.5: Wrench fixes all audit findings.
+
+    All completeness and hardening findings are mandatory.
+    Polish findings are discretionary but included in prompt.
+    On resume: git reset + clean to discard partial work.
+    """
+    findings = state.findings.get("current", [])
+    if not findings:
+        emitter.emit("audit_clean", issue=state.issue_number, stage="stage3.5_audit_fix")
+        return state
+
+    repo = config.repo_path
+    git_ops = GitOperations(repo)
+    await git_ops.reset_hard("HEAD")
+    await git_ops.clean()
+
+    findings_text = _format_findings(findings)
+    context = {
+        "issue_number": state.issue_number,
+        "branch": state.branch or "",
+        "findings_text": findings_text,
+        "round": state.cycle.cycle1_round,
+    }
+
+    prompt = render_template(config.factory_path, "wrench_fix.j2", context)
+    if not prompt:
+        prompt = _build_fix_prompt(state, findings_text)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="wrench", cli="opencode")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="wrench",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    if not result.success:
+        raise RuntimeError(f"Audit fix failed: {result.error or result.stderr[:500]}")
+
+    state.findings["current"] = []
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+def _format_findings(findings: list) -> str:
+    lines = []
+    for i, f in enumerate(findings, 1):
+        category = f.get("category", "unknown")
+        desc = f.get("description", f.get("raw_text", str(f)))
+        lines.append(f"{i}. [{category.upper()}] {desc}")
+    return "\n".join(lines)
+
+
+def _build_fix_prompt(state: PipelineState, findings_text: str) -> str:
+    return (
+        f"You are Wrench, the fix agent.\n\n"
+        f"Fix the following audit findings for issue #{state.issue_number}.\n"
+        f"Branch: {state.branch}\n\n"
+        f"Findings:\n{findings_text}\n\n"
+        f"All completeness and hardening findings are mandatory.\n"
+        f"Polish findings are discretionary.\n\n"
+        f"Before starting, read factory/AGENT-RULES.md.\n\n"
+        f"RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/stages/stage3_audit.py
+++ b/python/src/railclaw_pipeline/stages/stage3_audit.py
@@ -1,0 +1,103 @@
+"""Stage 3: Audit — Scope completeness audit, findings-only output."""
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+async def run_audit(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    runner: AgentRunner,
+) -> PipelineState:
+    """Stage 3: Scope completeness audit.
+
+    Produces findings list only — no verdict (PASS/REVISION).
+    Checks PLAN.md deliverables against actual implementation.
+    """
+    context = {
+        "issue_number": state.issue_number,
+        "branch": state.branch or "",
+        "pr_number": state.pr_number,
+    }
+
+    prompt = render_template(config.factory_path, "scope_audit.j2", context)
+    if not prompt:
+        prompt = _build_audit_prompt(state, config)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="scope", cli="opencode")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="scope",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    findings = _parse_audit_findings(result.stdout)
+
+    history = state.findings.get("history", [])
+    history.extend(state.findings.get("current", []))
+    state.findings = {"current": findings, "history": history}
+
+    emitter.emit("findings", issue=state.issue_number, stage="stage3_audit", count=len(findings))
+
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+def _parse_audit_findings(output: str) -> list[dict[str, Any]]:
+    """Parse findings from Scope audit output."""
+    findings: list[dict[str, Any]] = []
+    pattern = re.compile(
+        r"FINDING_START\s*\n(.*?)\nFINDING_END",
+        re.DOTALL,
+    )
+    for match in pattern.finditer(output):
+        block = match.group(1).strip()
+        finding: dict[str, Any] = {}
+        for line in block.splitlines():
+            line = line.strip()
+            if ":" in line:
+                key, _, value = line.partition(":")
+                finding[key.strip()] = value.strip()
+        if finding:
+            findings.append(finding)
+
+    if not findings:
+        fallback_pattern = re.compile(
+            r"\[(COMPLETENESS|HARDENING|POLISH)\]\s*(.*)",
+        )
+        for match in fallback_pattern.finditer(output):
+            findings.append({
+                "category": match.group(1).lower(),
+                "description": match.group(2).strip(),
+            })
+
+    return findings
+
+
+def _build_audit_prompt(state: PipelineState, config: PipelineConfig) -> str:
+    return (
+        f"You are Scope, the audit agent.\n\n"
+        f"Perform a completeness audit for issue #{state.issue_number}.\n"
+        f"Branch: {state.branch}\n\n"
+        f"Check PLAN.md deliverables against actual implementation.\n"
+        f"Report findings as FINDING_START/FINDING_END blocks.\n\n"
+        f"Before starting, read factory/AGENT-RULES.md.\n\n"
+        f"RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/stages/stage4_review.py
+++ b/python/src/railclaw_pipeline/stages/stage4_review.py
@@ -1,0 +1,107 @@
+"""Stage 4: Code Review — Scope performs full code review with verdict."""
+
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+
+async def run_review(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    runner: AgentRunner,
+) -> PipelineState:
+    """Stage 4: Scope code review with structured verdict.
+
+    Output: findings list WITH verdict — PASS or REVISION.
+    Each review uses a fresh Scope session.
+    """
+    context = {
+        "issue_number": state.issue_number,
+        "branch": state.branch or "",
+        "pr_number": state.pr_number,
+    }
+
+    prompt = render_template(config.factory_path, "scope_review.j2", context)
+    if not prompt:
+        prompt = _build_review_prompt(state)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="scope", cli="opencode")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="scope",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    verdict = _parse_verdict(result.stdout)
+    findings = _parse_review_findings(result.stdout)
+
+    state.cycle.scope_verdict = verdict
+
+    history = state.findings.get("history", [])
+    history.extend(state.findings.get("current", []))
+    state.findings = {"current": findings, "history": history}
+
+    emitter.emit("review_result", issue=state.issue_number, verdict=verdict, findings=len(findings))
+
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+def _parse_verdict(output: str) -> str:
+    """Extract verdict from review output."""
+    match = re.search(r"verdict:\s*(pass|revision|needs-human)", output, re.IGNORECASE)
+    if match:
+        return match.group(1).lower()
+    if re.search(r"REVIEW_START.*?verdict:\s*(pass|revision|needs-human)", output, re.DOTALL | re.IGNORECASE):
+        m = re.search(r"verdict:\s*(\S+)", output, re.IGNORECASE)
+        if m:
+            return m.group(1).lower()
+    if "RESULT_START" in output and "status: success" in output:
+        return "pass"
+    return "revision"
+
+
+def _parse_review_findings(output: str) -> list[dict[str, Any]]:
+    """Parse findings from review output."""
+    findings: list[dict[str, Any]] = []
+    pattern = re.compile(r"FINDING_START\s*\n(.*?)\nFINDING_END", re.DOTALL)
+    for match in pattern.finditer(output):
+        block = match.group(1).strip()
+        finding: dict[str, Any] = {}
+        for line in block.splitlines():
+            line = line.strip()
+            if ":" in line:
+                key, _, value = line.partition(":")
+                finding[key.strip()] = value.strip()
+        if finding:
+            findings.append(finding)
+    return findings
+
+
+def _build_review_prompt(state: PipelineState) -> str:
+    pr_info = f"PR: #{state.pr_number}\n" if state.pr_number else ""
+    return (
+        f"You are Scope, the code review agent.\n\n"
+        f"Review the code for issue #{state.issue_number}.\n"
+        f"Branch: {state.branch}\n"
+        f"{pr_info}\n"
+        f"Provide a verdict (pass/revision) and list any findings.\n\n"
+        f"Before starting, read factory/AGENT-RULES.md.\n\n"
+        f"RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/stages/stage5_fix_loop.py
+++ b/python/src/railclaw_pipeline/stages/stage5_fix_loop.py
@@ -1,0 +1,98 @@
+"""Stage 5: Fix Loop — Wrench fixes Scope review findings, max 5 rounds."""
+
+import logging
+from datetime import datetime, timezone
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+MAX_FIX_ROUNDS = 5
+
+
+async def run_fix_loop(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    runner: AgentRunner,
+) -> PipelineState:
+    """Stage 5: Wrench fixes review findings.
+
+    Runs up to MAX_FIX_ROUNDS rounds. On resume, resets working tree.
+    Escalation at round 3 (Wrench Sr available) and round 5 (Chris mandatory).
+    """
+    current_findings = state.findings.get("current", [])
+    if not current_findings:
+        emitter.emit("fix_loop_clean", issue=state.issue_number)
+        return state
+
+    round_num = state.cycle.cycle1_round
+    logger.info("Fix loop round %d for issue #%d", round_num + 1, state.issue_number)
+
+    repo = config.repo_path
+    git_ops = GitOperations(repo)
+    await git_ops.reset_hard("HEAD")
+    await git_ops.clean()
+
+    findings_text = _format_findings(current_findings)
+    context = {
+        "issue_number": state.issue_number,
+        "branch": state.branch or "",
+        "findings_text": findings_text,
+        "round": round_num + 1,
+    }
+
+    prompt = render_template(config.factory_path, "wrench_fix.j2", context)
+    if not prompt:
+        prompt = _build_fix_prompt(state, findings_text, round_num + 1)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="wrench", cli="opencode")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="wrench",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    if not result.success:
+        raise RuntimeError(f"Fix loop round {round_num + 1} failed: {result.error or result.stderr[:500]}")
+
+    history = state.findings.get("history", [])
+    history.extend(current_findings)
+    state.findings = {"current": [], "history": history}
+
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+def _format_findings(findings: list) -> str:
+    lines = []
+    for i, f in enumerate(findings, 1):
+        sev = f.get("severity", "info")
+        desc = f.get("description", f.get("raw_text", str(f)))
+        cat = f.get("category", "general")
+        lines.append(f"{i}. [{sev.upper()}] [{cat.upper()}] {desc}")
+    return "\n".join(lines)
+
+
+def _build_fix_prompt(state: PipelineState, findings_text: str, round_num: int) -> str:
+    return (
+        f"You are Wrench, the fix agent.\n\n"
+        f"Fix the following review findings for issue #{state.issue_number}, round {round_num}.\n"
+        f"Branch: {state.branch}\n\n"
+        f"Findings:\n{findings_text}\n\n"
+        f"All completeness and hardening findings are mandatory.\n"
+        f"Commit with: fix(pipeline): address review findings round {round_num}\n\n"
+        f"Before starting, read factory/AGENT-RULES.md.\n\n"
+        f"RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/stages/stage7_docs.py
+++ b/python/src/railclaw_pipeline/stages/stage7_docs.py
@@ -1,0 +1,132 @@
+"""Stage 7: Quill docs — opt-in documentation updates.
+
+Quill only runs when the issue or PLAN.md references doc-impacting changes.
+Advisory/non-blocking — does NOT prevent merge.
+"""
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.prompts.loader import render_template
+from railclaw_pipeline.runner.agent import AgentRunner
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+DOCS_INDICATORS = [
+    "docs:",
+    "documentation",
+    "readme",
+    "api docs",
+    "changelog",
+    "architectur",
+    "guide",
+    "tutorial",
+    "inline docs",
+    "jsdoc",
+    "docstring",
+]
+
+
+async def run_docs(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+    runner: AgentRunner | None = None,
+) -> PipelineState:
+    """Stage 7: Quill docs — opt-in, advisory, non-blocking.
+
+    Checks issue body and PLAN.md for doc-impacting keywords.
+    If found and runner provided, spawns Quill for doc updates.
+    If not found, skips entirely.
+    """
+    should_run = _should_run_docs(state, config)
+
+    if not should_run:
+        emitter.emit("docs_skip", issue=state.issue_number, reason="no_doc_indicators")
+        if state.timestamps:
+            state.timestamps.last_updated = datetime.now(timezone.utc)
+        save_state(state, config.state_path)
+        return state
+
+    if runner is None:
+        emitter.emit("docs_skip", issue=state.issue_number, reason="no_runner")
+        if state.timestamps:
+            state.timestamps.last_updated = datetime.now(timezone.utc)
+        save_state(state, config.state_path)
+        return state
+
+    emitter.emit("docs_start", issue=state.issue_number)
+
+    context = {
+        "issue_number": state.issue_number,
+        "branch": state.branch or "",
+        "pr_number": state.pr_number or "",
+        "repo_path": str(config.repo_path),
+    }
+
+    prompt = render_template(config.factory_path, "quill_docs.j2", context)
+    if not prompt:
+        prompt = _build_docs_prompt(state)
+
+    emitter.emit("agent_start", issue=state.issue_number, agent="quill", cli="opencode")
+    result = await runner.run(prompt)
+    emitter.emit(
+        "agent_end",
+        issue=state.issue_number,
+        agent="quill",
+        cli="opencode",
+        duration_s=result.duration,
+        success=result.success,
+    )
+
+    if result.success:
+        git_ops = GitOperations(config.repo_path)
+        await git_ops.add("README.md", "ARCHITECTURE.md", "docs/", "*.md")
+        if await git_ops.is_dirty():
+            await git_ops.commit(f"docs: update documentation for issue #{state.issue_number}")
+            await git_ops.push()
+            emitter.emit("docs_committed", issue=state.issue_number)
+    else:
+        logger.warning(
+            "Quill docs failed for issue #%d (non-blocking): %s",
+            state.issue_number,
+            result.error or result.stderr[:300],
+        )
+        emitter.emit("docs_skip", issue=state.issue_number, reason="quill_failed")
+
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+def _should_run_docs(state: PipelineState, config: PipelineConfig) -> bool:
+    """Check if docs should run based on issue body and PLAN.md content."""
+    plan_path = config.factory_path / "PLAN.md"
+    if plan_path.exists():
+        plan_text = plan_path.read_text(encoding="utf-8").lower()
+        for indicator in DOCS_INDICATORS:
+            if indicator in plan_text:
+                return True
+
+    return False
+
+
+def _build_docs_prompt(state: PipelineState) -> str:
+    return (
+        "You are Quill, the documentation agent.\n\n"
+        f"Review and update documentation for issue #{state.issue_number}.\n"
+        f"Branch: {state.branch}\n\n"
+        "Check README.md, ARCHITECTURE.md, docs/*, and inline documentation.\n"
+        "Update or create documentation as needed.\n"
+        "Doc-only changes — no code changes, no test changes.\n"
+        "Commit prefix MUST be 'docs: <description>'.\n\n"
+        "Before starting, read factory/AGENT-RULES.md.\n\n"
+        "RESULT_START\nstatus: success\nRESULT_END"
+    )

--- a/python/src/railclaw_pipeline/stages/stage8_approval.py
+++ b/python/src/railclaw_pipeline/stages/stage8_approval.py
@@ -1,0 +1,159 @@
+"""Stage 8: Approval gate — wait for human approval via file protocol."""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.state.models import PipelineState, PipelineStatus
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+APPROVAL_POLL_INTERVAL = 30
+DEFAULT_APPROVAL_TIMEOUT = 86400
+
+
+async def run_approval(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+) -> PipelineState:
+    """Stage 8: Wait for human approval via file protocol.
+
+    Protocol:
+    1. Write awaiting-approval.json with PR details and summary
+    2. Emit AWAITING_APPROVAL event
+    3. Poll for approve-{pr}.json or abort-{pr}.json
+    4. On approval: continue to merge
+    5. On abort: set status to FAILED
+    6. On timeout: set status to FAILED
+    """
+    pr_number = state.pr_number
+    if not pr_number:
+        raise RuntimeError("No PR number — cannot wait for approval")
+
+    factory = config.factory_path
+    awaiting_path = factory / f"awaiting-approval-{pr_number}.json"
+    approve_path = factory / f"approve-{pr_number}.json"
+    abort_path = factory / f"abort-{pr_number}.json"
+
+    summary = _build_approval_summary(state)
+
+    awaiting_data = {
+        "pr_number": pr_number,
+        "issue_number": state.issue_number,
+        "branch": state.branch,
+        "stage": state.stage.value,
+        "cycle1_round": state.cycle.cycle1_round,
+        "cycle2_round": state.cycle.cycle2_round,
+        "summary": summary,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    awaiting_path.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write(awaiting_path, json.dumps(awaiting_data, indent=2))
+
+    state.status = PipelineStatus.PAUSED
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+
+    emitter.emit("awaiting_approval", issue=state.issue_number, pr=pr_number, summary=summary)
+
+    timeout = config.timing.get("approvalTimeout", DEFAULT_APPROVAL_TIMEOUT)
+    decision = await _poll_for_decision(approve_path, abort_path, timeout)
+
+    awaiting_path.unlink(missing_ok=True)
+
+    if decision == "approved":
+        state.status = PipelineStatus.RUNNING
+        emitter.emit("approval_received", issue=state.issue_number, pr=pr_number, decision="approved")
+    elif decision == "aborted":
+        state.status = PipelineStatus.FAILED
+        state.error = {"category": "approval_aborted", "message": "Pipeline aborted by user"}
+        emitter.emit("approval_received", issue=state.issue_number, pr=pr_number, decision="aborted")
+    else:
+        state.status = PipelineStatus.FAILED
+        state.error = {"category": "approval_timeout", "message": f"Approval timed out after {timeout}s"}
+        emitter.emit("approval_timeout", issue=state.issue_number, pr=pr_number)
+
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+        state.timestamps.stage_entered = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+async def _poll_for_decision(
+    approve_path: Path,
+    abort_path: Path,
+    timeout: float,
+) -> str:
+    """Poll for approval or abort signal file.
+
+    Returns "approved", "aborted", or "timeout".
+    """
+    elapsed = 0.0
+    while elapsed < timeout:
+        if approve_path.exists():
+            try:
+                approve_path.unlink()
+            except OSError:
+                pass
+            return "approved"
+
+        if abort_path.exists():
+            try:
+                abort_path.unlink()
+            except OSError:
+                pass
+            return "aborted"
+
+        await asyncio.sleep(APPROVAL_POLL_INTERVAL)
+        elapsed += APPROVAL_POLL_INTERVAL
+
+    return "timeout"
+
+
+def _build_approval_summary(state: PipelineState) -> str:
+    parts = [f"Issue #{state.issue_number}"]
+    if state.branch:
+        parts.append(f"Branch: {state.branch}")
+    if state.pr_number:
+        parts.append(f"PR: #{state.pr_number}")
+    parts.append(f"Cycle 1 rounds: {state.cycle.cycle1_round}")
+    parts.append(f"Cycle 2 rounds: {state.cycle.cycle2_round}")
+
+    findings_count = len(state.findings.get("current", []))
+    history_count = len(state.findings.get("history", []))
+    parts.append(f"Open findings: {findings_count}")
+    parts.append(f"Resolved findings: {history_count}")
+
+    if state.cycle.gemini_clean:
+        parts.append("Gemini review: CLEAN")
+
+    return " | ".join(parts)
+
+
+def _atomic_write(path: Path, data: str) -> None:
+    """Atomic write using tempfile + os.replace."""
+    import os
+    import tempfile
+
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix="approval_")
+    try:
+        os.write(fd, data.encode("utf-8"))
+        os.fsync(fd)
+        os.close(fd)
+        os.replace(tmp_path, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/python/src/railclaw_pipeline/stages/stage8c_merge.py
+++ b/python/src/railclaw_pipeline/stages/stage8c_merge.py
@@ -1,0 +1,96 @@
+"""Stage 8c: Pre-merge validation and squash merge."""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.github.pr import PrClient
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+MERGE_RETRY_COUNT = 3
+MERGE_RETRY_DELAY = 10
+
+
+async def run_merge(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+) -> PipelineState:
+    """Stage 8c: Pre-merge validation + squash merge + branch cleanup.
+
+    Steps:
+    1. Verify PR is mergeable
+    2. Verify CI status (if available)
+    3. Generate merge summary
+    4. Squash merge via gh
+    5. Delete feature branch (local + remote)
+    6. Pull latest main
+    """
+    pr_number = state.pr_number
+    if not pr_number:
+        raise RuntimeError("No PR number — cannot merge")
+
+    pr_client = PrClient(config.repo_path)
+    git_ops = GitOperations(config.repo_path)
+
+    mergeable, merge_state = await pr_client.is_mergeable(pr_number)
+
+    if not mergeable:
+        for attempt in range(MERGE_RETRY_COUNT):
+            emitter.emit(
+                "merge_retry",
+                issue=state.issue_number,
+                pr=pr_number,
+                attempt=attempt + 1,
+                state=merge_state,
+            )
+            await asyncio.sleep(MERGE_RETRY_DELAY * (attempt + 1))
+            mergeable, merge_state = await pr_client.is_mergeable(pr_number)
+            if mergeable:
+                break
+
+        if not mergeable:
+            raise RuntimeError(
+                f"PR #{pr_number} is not mergeable (state: {merge_state}). "
+                f"Resolve conflicts or CI failures before merging."
+            )
+
+    emitter.emit("merge_start", issue=state.issue_number, pr=pr_number)
+
+    try:
+        merge_output = await pr_client.merge(pr_number, merge_method="squash")
+        emitter.emit(
+            "merge_complete",
+            issue=state.issue_number,
+            pr=pr_number,
+            output=merge_output[:500],
+        )
+    except Exception as exc:
+        raise RuntimeError(f"Failed to merge PR #{pr_number}: {exc}") from exc
+
+    if state.branch:
+        try:
+            await git_ops.delete_branch(state.branch, force=True)
+        except Exception:
+            logger.warning("Failed to delete local branch %s", state.branch, exc_info=True)
+
+        try:
+            await git_ops.delete_remote_branch(state.branch)
+        except Exception:
+            logger.warning("Failed to delete remote branch %s", state.branch, exc_info=True)
+
+    await git_ops.checkout("main")
+    await git_ops.pull("origin", "main")
+
+    state.timestamps.stage_entered = datetime.now(timezone.utc)
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state

--- a/python/src/railclaw_pipeline/stages/stage8c_merge.py
+++ b/python/src/railclaw_pipeline/stages/stage8c_merge.py
@@ -75,6 +75,9 @@ async def run_merge(
     except Exception as exc:
         raise RuntimeError(f"Failed to merge PR #{pr_number}: {exc}") from exc
 
+    await git_ops.checkout("main")
+    await git_ops.pull("origin", "main")
+
     if state.branch:
         try:
             await git_ops.delete_branch(state.branch, force=True)
@@ -85,9 +88,6 @@ async def run_merge(
             await git_ops.delete_remote_branch(state.branch)
         except Exception:
             logger.warning("Failed to delete remote branch %s", state.branch, exc_info=True)
-
-    await git_ops.checkout("main")
-    await git_ops.pull("origin", "main")
 
     state.timestamps.stage_entered = datetime.now(timezone.utc)
     if state.timestamps:

--- a/python/src/railclaw_pipeline/stages/stage9_deploy.py
+++ b/python/src/railclaw_pipeline/stages/stage9_deploy.py
@@ -1,0 +1,130 @@
+"""Stage 9: PM2 deploy — pull, install, restart, health check."""
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.git import GitOperations
+from railclaw_pipeline.runner.subprocess_runner import SubprocessError, run_subprocess
+from railclaw_pipeline.state.models import PipelineState
+from railclaw_pipeline.state.persistence import save_state
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HEALTH_URL = "http://localhost:3000/health"
+HEALTH_CHECK_ATTEMPTS = 12
+HEALTH_CHECK_INTERVAL = 5
+
+
+async def run_deploy(
+    state: PipelineState,
+    config: PipelineConfig,
+    emitter: EventEmitter,
+) -> PipelineState:
+    """Stage 9: Deploy via PM2 restart on the Pi.
+
+    Steps:
+    1. Ensure on main and up to date
+    2. npm ci --production
+    3. PM2 start or restart
+    4. Health check (curl localhost:3000/health, up to 60s)
+    """
+    repo = config.repo_path
+    git_ops = GitOperations(repo)
+
+    emitter.emit("deploy_start", issue=state.issue_number)
+
+    await git_ops.checkout("main")
+    await git_ops.pull("origin", "main")
+
+    emitter.emit("deploy_install_start", issue=state.issue_number)
+    try:
+        await run_subprocess(
+            ["npm", "ci", "--production"],
+            cwd=repo,
+            timeout=120,
+        )
+    except SubprocessError as exc:
+        raise RuntimeError(f"npm ci --production failed: {exc}") from exc
+    emitter.emit("deploy_install_complete", issue=state.issue_number)
+
+    pm2_config = config.pm2 or {}
+    process_name = pm2_config.get("processName", "railclaw-mc")
+    ecosystem_path = pm2_config.get("ecosystemPath", "ecosystem.config.cjs")
+
+    pm2_exists = await _check_pm2_process(process_name)
+
+    emitter.emit("deploy_pm2_start", issue=state.issue_number, exists=pm2_exists)
+    try:
+        if pm2_exists:
+            await run_subprocess(
+                ["pm2", "restart", "--update-env", process_name],
+                cwd=repo,
+                timeout=60,
+            )
+        else:
+            await run_subprocess(
+                ["pm2", "start", ecosystem_path, "--env", "production", "--only", process_name],
+                cwd=repo,
+                timeout=60,
+            )
+    except SubprocessError as exc:
+        raise RuntimeError(
+            f"pm2 {'restart' if pm2_exists else 'start'} failed: {exc}"
+        ) from exc
+
+    try:
+        await run_subprocess(["pm2", "save"], timeout=15)
+    except SubprocessError:
+        logger.warning("pm2 save failed (non-critical)", exc_info=True)
+
+    emitter.emit("deploy_health_check_start", issue=state.issue_number)
+    health_timeout = config.timing.get("healthCheckTimeout", 60)
+
+    healthy = await _health_check(health_timeout)
+    if not healthy:
+        raise RuntimeError(
+            "Health check failed — service did not respond within "
+            f"{HEALTH_CHECK_ATTEMPTS * HEALTH_CHECK_INTERVAL}s after PM2 restart"
+        )
+
+    emitter.emit("deploy_success", issue=state.issue_number)
+
+    if state.timestamps:
+        state.timestamps.last_updated = datetime.now(timezone.utc)
+    save_state(state, config.state_path)
+    return state
+
+
+async def _check_pm2_process(process_name: str) -> bool:
+    """Check if a PM2 process with the given name exists."""
+    try:
+        result = await run_subprocess(
+            ["pm2", "jlist"],
+            timeout=15,
+        )
+        import json
+        processes = json.loads(result.stdout)
+        return any(p.get("name") == process_name for p in processes)
+    except (SubprocessError, json.JSONDecodeError, OSError):
+        return False
+
+
+async def _health_check(timeout_s: float) -> bool:
+    """Wait for health endpoint to respond. Returns True if healthy."""
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            result = await run_subprocess(
+                ["curl", "-sf", DEFAULT_HEALTH_URL],
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return True
+        except SubprocessError:
+            pass
+        await asyncio.sleep(HEALTH_CHECK_INTERVAL)
+    return False

--- a/python/src/railclaw_pipeline/state/__init__.py
+++ b/python/src/railclaw_pipeline/state/__init__.py
@@ -1,0 +1,17 @@
+"""Pipeline state models and persistence."""
+
+from railclaw_pipeline.state.models import (
+    CycleState,
+    PipelineStage,
+    PipelineState,
+    PipelineStatus,
+    Timestamps,
+)
+
+__all__ = [
+    "CycleState",
+    "PipelineStage",
+    "PipelineState",
+    "PipelineStatus",
+    "Timestamps",
+]

--- a/python/src/railclaw_pipeline/state/lock.py
+++ b/python/src/railclaw_pipeline/state/lock.py
@@ -26,16 +26,25 @@ class StateLock:
         self._lock_file = open(self.lock_path, "w")
         
         start_time = time.monotonic()
-        while True:
-            try:
-                fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
-                return
-            except (IOError, OSError):
-                if time.monotonic() - start_time >= self.timeout:
-                    raise StateLockError(
-                        f"Failed to acquire lock {self.lock_path} after {self.timeout}s"
-                    )
-                time.sleep(0.1)
+        try:
+            while True:
+                try:
+                    fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    return
+                except (IOError, OSError):
+                    if time.monotonic() - start_time >= self.timeout:
+                        raise StateLockError(
+                            f"Failed to acquire lock {self.lock_path} after {self.timeout}s"
+                        )
+                    time.sleep(0.1)
+        except BaseException:
+            if self._lock_file:
+                try:
+                    self._lock_file.close()
+                except (IOError, OSError):
+                    pass
+            self._lock_file = None
+            raise
     
     def release(self) -> None:
         """Release lock if held."""

--- a/python/src/railclaw_pipeline/state/lock.py
+++ b/python/src/railclaw_pipeline/state/lock.py
@@ -3,7 +3,7 @@
 import fcntl
 import time
 from pathlib import Path
-from typing import TextIO
+from typing import Any, TextIO
 
 
 class StateLockError(Exception):

--- a/python/src/railclaw_pipeline/state/lock.py
+++ b/python/src/railclaw_pipeline/state/lock.py
@@ -1,0 +1,56 @@
+"""File-based advisory lock for concurrent access."""
+
+import fcntl
+import time
+from pathlib import Path
+from typing import TextIO
+
+
+class StateLockError(Exception):
+    """Raised when lock acquisition fails."""
+    pass
+
+
+class StateLock:
+    """File-based advisory lock using fcntl."""
+    
+    def __init__(self, lock_path: Path, timeout: float = 10.0):
+        self.lock_path = lock_path
+        self.timeout = timeout
+        self._lock_file: TextIO | None = None
+    
+    def acquire(self) -> None:
+        """Acquire exclusive lock with timeout."""
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        
+        self._lock_file = open(self.lock_path, "w")
+        
+        start_time = time.monotonic()
+        while True:
+            try:
+                fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return
+            except (IOError, OSError):
+                if time.monotonic() - start_time >= self.timeout:
+                    raise StateLockError(
+                        f"Failed to acquire lock {self.lock_path} after {self.timeout}s"
+                    )
+                time.sleep(0.1)
+    
+    def release(self) -> None:
+        """Release lock if held."""
+        if self._lock_file is not None:
+            try:
+                fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_UN)
+                self._lock_file.close()
+            except (IOError, OSError):
+                pass
+            finally:
+                self._lock_file = None
+    
+    def __enter__(self) -> "StateLock":
+        self.acquire()
+        return self
+    
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.release()

--- a/python/src/railclaw_pipeline/state/models.py
+++ b/python/src/railclaw_pipeline/state/models.py
@@ -1,0 +1,71 @@
+"""Pipeline state models using Pydantic for validation."""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class PipelineStage(StrEnum):
+    """Operational stages - where the pipeline is in the workflow."""
+    IDLE = "idle"
+    STAGE0_PREFLIGHT = "stage0_preflight"
+    STAGE1_BLUEPRINT = "stage1_blueprint"
+    STAGE2_WRENCH = "stage2_wrench"
+    STAGE2_5_CREATE_PR = "stage2.5_create_pr"
+    STAGE3_AUDIT = "stage3_audit"
+    STAGE3_5_AUDIT_FIX = "stage3.5_audit_fix"
+    STAGE4_REVIEW = "stage4_review"
+    STAGE5_FIX_LOOP = "stage5_fix_loop"
+    CYCLE2_GEMINI_LOOP = "cycle2_gemini_loop"
+    STAGE7_DOCS = "stage7_docs"
+    STAGE8_APPROVAL = "stage8_approval"
+    STAGE8C_MERGE = "stage8c_merge"
+    STAGE9_DEPLOY = "stage9_deploy"
+    STAGE10_QA = "stage10_qa"
+    STAGE11_HOTFIX = "stage11_hotfix"
+    STAGE12_LESSONS = "stage12_lessons"
+
+
+class PipelineStatus(StrEnum):
+    """Execution status - how the pipeline is running."""
+    RUNNING = "running"
+    PAUSED = "paused"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class Timestamps(BaseModel):
+    """Timestamp tracking for pipeline execution."""
+    started: datetime
+    stage_entered: datetime
+    last_updated: datetime
+
+
+class CycleState(BaseModel):
+    """Cycle tracking for fix loops."""
+    cycle1_round: int = 0
+    cycle2_round: int = 0
+    scope_verdict: str = ""
+    gemini_clean: bool = False
+
+
+class PipelineState(BaseModel):
+    """Complete pipeline state."""
+    version: int = 1
+    issue_number: int
+    pr_number: int | None = None
+    branch: str | None = None
+    stage: PipelineStage = PipelineStage.IDLE
+    status: PipelineStatus = PipelineStatus.RUNNING
+    milestone_mode: bool = False
+    milestone_label: str | None = None
+    cycle: CycleState = Field(default_factory=CycleState)
+    plan_path: str | None = None
+    repo_path: str | None = None
+    timestamps: Timestamps | None = None
+    gemini_tracking: dict[str, Any] = Field(default_factory=lambda: {"pending_poll": False})
+    findings: dict[str, Any] = Field(default_factory=lambda: {"current": [], "history": []})
+    error: dict[str, Any] | None = None
+    retry_count: int = 0

--- a/python/src/railclaw_pipeline/state/persistence.py
+++ b/python/src/railclaw_pipeline/state/persistence.py
@@ -1,0 +1,60 @@
+"""Atomic state persistence with crash recovery."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from railclaw_pipeline.state.models import PipelineState
+
+
+class StatePersistenceError(Exception):
+    """Raised when state persistence fails."""
+    pass
+
+
+def save_state(state: PipelineState, state_path: Path) -> None:
+    """Atomic write: write to temp file → flush → os.replace().
+    
+    os.replace() is atomic on POSIX (Linux/macOS), ensuring the target file
+    is never in a partially-written state.
+    """
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    data = state.model_dump_json(indent=2)
+    
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(state_path.parent),
+        suffix=".tmp",
+        prefix="state_"
+    )
+    
+    try:
+        os.write(fd, data.encode("utf-8"))
+        os.fsync(fd)
+        os.close(fd)
+        os.replace(tmp_path, str(state_path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_state(state_path: Path) -> PipelineState | None:
+    """Load state.json. Returns None if file doesn't exist or is invalid."""
+    if not state_path.exists():
+        return None
+    
+    try:
+        data = state_path.read_text()
+        return PipelineState.model_validate_json(data)
+    except (json.JSONDecodeError, ValueError, OSError) as e:
+        raise StatePersistenceError(f"Failed to load state from {state_path}: {e}") from e
+
+
+def delete_state(state_path: Path) -> None:
+    """Delete state file if it exists."""
+    if state_path.exists():
+        state_path.unlink()

--- a/python/src/railclaw_pipeline/state/persistence.py
+++ b/python/src/railclaw_pipeline/state/persistence.py
@@ -43,10 +43,10 @@ def save_state(state: PipelineState, state_path: Path) -> None:
         raise
 
 
-def load_state(state_path: Path) -> PipelineState | None:
-    """Load state.json. Returns None if file doesn't exist or is invalid."""
+def load_state(state_path: Path) -> PipelineState:
+    """Load state.json. Raises FileNotFoundError if file doesn't exist."""
     if not state_path.exists():
-        return None
+        raise FileNotFoundError(f"State file not found: {state_path}")
     
     try:
         data = state_path.read_text()

--- a/python/src/railclaw_pipeline/state/persistence.py
+++ b/python/src/railclaw_pipeline/state/persistence.py
@@ -30,9 +30,10 @@ def save_state(state: PipelineState, state_path: Path) -> None:
     )
     
     try:
-        os.write(fd, data.encode("utf-8"))
-        os.fsync(fd)
-        os.close(fd)
+        with os.fdopen(fd, "w") as tmp_file:
+            tmp_file.write(data)
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
         os.replace(tmp_path, str(state_path))
     except BaseException:
         try:

--- a/python/tests/test_agent_runner.py
+++ b/python/tests/test_agent_runner.py
@@ -16,8 +16,8 @@ def test_agent_config_build_args():
         args_template=["run", "--dir", "{dir}", "{prompt}"],
         workdir=Path("/tmp"),
     )
-    args = config.build_args(Path("/work"), "hello world")
-    assert args == ["run", "--dir", "/work", "hello world"]
+    args = config.build_args(Path("/work"))
+    assert args == ["run", "--dir", "/work"]
 
 
 def test_agent_config_model_substitution():
@@ -26,10 +26,10 @@ def test_agent_config_model_substitution():
         model="gpt-5",
         args_template=["--model", "{model}", "{prompt}"],
     )
-    args = config.build_args(Path("/tmp"), "test prompt")
+    args = config.build_args(Path("/tmp"))
     assert args[0] == "--model"
     assert args[1] == "gpt-5"
-    assert args[2] == "test prompt"
+    assert len(args) == 2
 
 
 def test_parse_verdict_pass():

--- a/python/tests/test_agent_runner.py
+++ b/python/tests/test_agent_runner.py
@@ -1,0 +1,99 @@
+"""Tests for agent runner and subprocess execution."""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from railclaw_pipeline.runner.agent import AgentConfig, AgentResult
+from railclaw_pipeline.runner.subprocess_runner import AgentVerdict, parse_verdict
+
+
+def test_agent_config_build_args():
+    config = AgentConfig(
+        name="test",
+        command="echo",
+        args_template=["run", "--dir", "{dir}", "{prompt}"],
+        workdir=Path("/tmp"),
+    )
+    args = config.build_args(Path("/work"), "hello world")
+    assert args == ["run", "--dir", "/work", "hello world"]
+
+
+def test_agent_config_model_substitution():
+    config = AgentConfig(
+        name="test",
+        model="gpt-5",
+        args_template=["--model", "{model}", "{prompt}"],
+    )
+    args = config.build_args(Path("/tmp"), "test prompt")
+    assert args[0] == "--model"
+    assert args[1] == "gpt-5"
+    assert args[2] == "test prompt"
+
+
+def test_parse_verdict_pass():
+    assert parse_verdict("RESULT_START\nstatus: success\nRESULT_END") == AgentVerdict.PASS
+
+
+def test_parse_verdict_revision():
+    assert parse_verdict("RESULT_START\nstatus: failure\nRESULT_END") == AgentVerdict.REVISION
+
+
+def test_parse_verdict_needs_human():
+    assert parse_verdict("RESULT_START\nstatus: needs-human\nRESULT_END") == AgentVerdict.NEEDS_HUMAN
+
+
+def test_parse_verdict_timeout():
+    assert parse_verdict("RESULT_START\nstatus: timeout\nRESULT_END") == AgentVerdict.TIMEOUT
+
+
+def test_parse_verdict_error():
+    assert parse_verdict("RESULT_START\nstatus: error\nRESULT_END") == AgentVerdict.ERROR
+
+
+def test_parse_verdict_keyword_pass():
+    assert parse_verdict("verdict: pass - everything looks good") == AgentVerdict.PASS
+
+
+def test_parse_verdict_keyword_needs_human():
+    assert parse_verdict("This needs human review") == AgentVerdict.NEEDS_HUMAN
+
+
+def test_parse_verdict_fallback_zero_exit():
+    assert parse_verdict("some output", returncode=0) == AgentVerdict.PASS
+
+
+def test_parse_verdict_fallback_nonzero_exit():
+    assert parse_verdict("error output", returncode=1) == AgentVerdict.ERROR
+
+
+def test_agent_result_success():
+    result = AgentResult(
+        agent_name="test",
+        verdict=AgentVerdict.PASS,
+        duration=1.5,
+    )
+    assert result.success is True
+
+
+def test_agent_result_failure():
+    result = AgentResult(
+        agent_name="test",
+        verdict=AgentVerdict.ERROR,
+        error="something went wrong",
+    )
+    assert result.success is False
+
+
+def test_agent_result_to_dict():
+    result = AgentResult(
+        agent_name="wrench",
+        verdict=AgentVerdict.PASS,
+        duration=2.0,
+        returncode=0,
+    )
+    d = result.to_dict()
+    assert d["agent"] == "wrench"
+    assert d["verdict"] == "pass"
+    assert d["duration"] == 2.0

--- a/python/tests/test_approval_gate.py
+++ b/python/tests/test_approval_gate.py
@@ -1,0 +1,90 @@
+"""Tests for approval gate — file protocol."""
+
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.state.models import PipelineState, PipelineStage, PipelineStatus
+from railclaw_pipeline.stages.stage8_approval import run_approval
+
+
+@pytest.fixture
+def factory_dir(tmp_path):
+    return tmp_path / "factory"
+
+
+@pytest.fixture
+def config(factory_dir):
+    return PipelineConfig({
+        "repoPath": str(factory_dir / "repo"),
+        "factoryPath": str(factory_dir),
+        "stateDir": ".pipeline-state",
+    })
+
+
+@pytest.fixture
+def emitter(tmp_path):
+    return EventEmitter(tmp_path / "events.jsonl")
+
+
+@pytest.fixture
+def state():
+    return PipelineState(
+        issue_number=42,
+        pr_number=7,
+        branch="feat/test",
+        stage=PipelineStage.STAGE8_APPROVAL,
+        timestamps=__import__("railclaw_pipeline.state.models", fromlist=["Timestamps"]).Timestamps(
+            started=datetime.now(timezone.utc),
+            stage_entered=datetime.now(timezone.utc),
+            last_updated=datetime.now(timezone.utc),
+        ),
+    )
+
+
+async def test_approval_approved(factory_dir, config, emitter, state):
+    approve_path = factory_dir / "approve-7.json"
+
+    async def create_approval():
+        await asyncio.sleep(0.1)
+        approve_path.parent.mkdir(parents=True, exist_ok=True)
+        approve_path.write_text(json.dumps({"approved": True}))
+
+    with patch("railclaw_pipeline.stages.stage8_approval.APPROVAL_POLL_INTERVAL", 0.05):
+        with patch("railclaw_pipeline.stages.stage8_approval.DEFAULT_APPROVAL_TIMEOUT", 5):
+            task = asyncio.create_task(create_approval())
+            result = await run_approval(state, config, emitter)
+            await task
+
+    assert result.status == PipelineStatus.RUNNING
+
+
+async def test_approval_aborted(factory_dir, config, emitter, state):
+    abort_path = factory_dir / "abort-7.json"
+
+    async def create_abort():
+        await asyncio.sleep(0.1)
+        abort_path.parent.mkdir(parents=True, exist_ok=True)
+        abort_path.write_text(json.dumps({"aborted": True}))
+
+    with patch("railclaw_pipeline.stages.stage8_approval.APPROVAL_POLL_INTERVAL", 0.05):
+        with patch("railclaw_pipeline.stages.stage8_approval.DEFAULT_APPROVAL_TIMEOUT", 5):
+            task = asyncio.create_task(create_abort())
+            result = await run_approval(state, config, emitter)
+            await task
+
+    assert result.status == PipelineStatus.FAILED
+    assert result.error is not None
+    assert "aborted" in result.error.get("category", "")
+
+
+async def test_approval_no_pr_raises(config, emitter):
+    state = PipelineState(issue_number=42, pr_number=None)
+    with pytest.raises(RuntimeError, match="No PR number"):
+        await run_approval(state, config, emitter)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -3,7 +3,7 @@
 import pytest
 from click.testing import CliRunner
 
-from railclaw_pipeline.cli import cli
+from railclaw_pipeline.cli import main as cli
 
 
 def test_cli_help():

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,25 @@
+"""Tests for CLI — basic invocation."""
+
+import pytest
+from click.testing import CliRunner
+
+from railclaw_pipeline.cli import cli
+
+
+def test_cli_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "pipeline" in result.output.lower() or "usage" in result.output.lower()
+
+
+def test_cli_run_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["run", "--help"])
+    assert result.exit_code == 0
+
+
+def test_cli_status_help():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["status", "--help"])
+    assert result.exit_code == 0

--- a/python/tests/test_gemini_polling.py
+++ b/python/tests/test_gemini_polling.py
@@ -1,0 +1,120 @@
+"""Tests for Gemini review polling — cycle 2 helpers."""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.review import ReviewResult
+from railclaw_pipeline.stages.cycle2_gemini import (
+    _extract_gemini_findings,
+    _parse_scope_findings,
+    _parse_verdict,
+)
+
+
+def test_parse_verdict_pass():
+    assert _parse_verdict("verdict: pass - all good") == "pass"
+
+
+def test_parse_verdict_revision():
+    assert _parse_verdict("verdict: revision needed") == "revision"
+
+
+def test_parse_verdict_needs_human():
+    assert _parse_verdict("verdict: needs-human - blocked") == "needs-human"
+
+
+def test_parse_verdict_result_block_success():
+    assert _parse_verdict("RESULT_START\nstatus: success\nRESULT_END") == "pass"
+
+
+def test_parse_verdict_default_revision():
+    assert _parse_verdict("random output without verdict") == "revision"
+
+
+def test_parse_scope_findings_with_blocks():
+    output = (
+        "Review output\n"
+        "FINDING_START\n"
+        "severity: high\n"
+        "description: missing tests\n"
+        "FINDING_END\n"
+        "more text\n"
+        "FINDING_START\n"
+        "severity: low\n"
+        "description: style issue\n"
+        "FINDING_END\n"
+    )
+    findings = _parse_scope_findings(output)
+    assert len(findings) == 2
+    assert findings[0]["severity"] == "high"
+    assert findings[1]["description"] == "style issue"
+
+
+def test_parse_scope_findings_empty():
+    assert _parse_scope_findings("") == []
+    assert _parse_scope_findings("no findings here") == []
+
+
+def test_extract_gemini_findings_clean():
+    result = ReviewResult(
+        findings=[],
+        is_clean=True,
+        has_formal_review=True,
+        raw_comments=[],
+        raw_reviews=[],
+    )
+    findings = _extract_gemini_findings(result)
+    assert findings == []
+
+
+def test_extract_gemini_findings_from_reviews():
+    result = ReviewResult(
+        findings=[],
+        is_clean=False,
+        has_formal_review=True,
+        raw_reviews=[
+            {
+                "body": '<details><summary>High: Bug</summary>\nFix this\n</details>',
+                "state": "CHANGES_REQUESTED",
+                "author": "gemini-bot",
+            }
+        ],
+        raw_comments=[],
+    )
+    findings = _extract_gemini_findings(result)
+    assert len(findings) >= 1
+
+
+def test_extract_gemini_findings_from_comments():
+    result = ReviewResult(
+        findings=[],
+        is_clean=False,
+        has_formal_review=False,
+        raw_reviews=[],
+        raw_comments=[
+            {"body": "Inline comment finding", "author": "gemini-bot"},
+        ],
+    )
+    findings = _extract_gemini_findings(result)
+    assert len(findings) == 1
+    assert "Inline comment finding" in findings[0]["description"]
+
+
+async def test_run_gemini_loop_no_pr_raises(tmp_path):
+    from railclaw_pipeline.state.models import PipelineState, PipelineStage
+    from railclaw_pipeline.stages.cycle2_gemini import run_gemini_loop
+
+    config = PipelineConfig({
+        "repoPath": str(tmp_path),
+        "factoryPath": str(tmp_path / "factory"),
+    })
+    emitter = EventEmitter(tmp_path / "events.jsonl")
+    state = PipelineState(issue_number=42, pr_number=None)
+    runner = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="No PR number"):
+        await run_gemini_loop(state, config, emitter, runner)

--- a/python/tests/test_gh.py
+++ b/python/tests/test_gh.py
@@ -1,0 +1,19 @@
+"""Tests for gh CLI wrapper."""
+
+import json
+
+import pytest
+
+from railclaw_pipeline.github.gh import GhClient, GhError
+
+
+def test_gh_client_init(tmp_path):
+    client = GhClient(tmp_path, timeout=30)
+    assert client.repo_path == tmp_path
+    assert client.timeout == 30
+
+
+async def test_gh_unauthenticated_raises(tmp_path):
+    client = GhClient(tmp_path, timeout=5)
+    result = await client.is_authenticated()
+    assert isinstance(result, bool)

--- a/python/tests/test_git.py
+++ b/python/tests/test_git.py
@@ -1,0 +1,39 @@
+"""Tests for git operations — sanitize and wrappers."""
+
+from pathlib import Path
+
+from railclaw_pipeline.github.git import sanitize_branch_name
+
+
+def test_sanitize_normal():
+    assert sanitize_branch_name("feat/issue-42-test") == "feat/issue-42-test"
+
+
+def test_sanitize_spaces():
+    result = sanitize_branch_name("feat/issue 42")
+    assert " " not in result
+
+
+def test_sanitize_semicolons():
+    result = sanitize_branch_name("feat;echo")
+    assert ";" not in result
+
+
+def test_sanitize_pipes():
+    result = sanitize_branch_name("feat|echo")
+    assert "|" not in result
+
+
+def test_sanitize_ampersand():
+    result = sanitize_branch_name("feat&&echo")
+    assert "&" not in result
+
+
+def test_sanitize_newlines():
+    result = sanitize_branch_name("feat\nmalicious")
+    assert "\n" not in result
+
+
+def test_sanitize_unicode():
+    result = sanitize_branch_name("feat/\u0000test")
+    assert "\u0000" not in result

--- a/python/tests/test_injection_resistance.py
+++ b/python/tests/test_injection_resistance.py
@@ -1,0 +1,81 @@
+"""Tests for injection resistance — SSTI and command injection."""
+
+import pytest
+
+from railclaw_pipeline.github.git import sanitize_branch_name
+from railclaw_pipeline.prompts.loader import create_template_env, SandboxedTemplateError, render_template
+from pathlib import Path
+
+
+def test_sanitize_branch_name_normal():
+    assert sanitize_branch_name("feat/issue-42") == "feat/issue-42"
+
+
+def test_sanitize_branch_name_injection():
+    malicious = "feat; rm -rf /"
+    sanitized = sanitize_branch_name(malicious)
+    assert ";" not in sanitized
+    assert " " not in sanitized
+
+
+def test_sanitize_branch_name_path_traversal():
+    malicious = "../../../etc/passwd"
+    sanitized = sanitize_branch_name(malicious)
+    assert sanitized.count(".") == 0 or ".." not in sanitized
+
+
+def test_sanitize_branch_name_backticks():
+    malicious = "feat`whoami`"
+    sanitized = sanitize_branch_name(malicious)
+    assert "`" not in sanitized
+
+
+def test_sanitize_branch_name_dollar():
+    malicious = "feat$(whoami)"
+    sanitized = sanitize_branch_name(malicious)
+    assert "$" not in sanitized
+    assert "(" not in sanitized
+
+
+def test_template_ssti_import(tmp_path):
+    env = create_template_env(tmp_path)
+    template_dir = tmp_path / "prompts" / "templates"
+    template_dir.mkdir(parents=True)
+
+    malicious_template = template_dir / "evil.j2"
+    malicious_template.write_text("{{ __import__('os').system('whoami') }}")
+
+    with pytest.raises(SandboxedTemplateError, match="unsafe"):
+        render_template(tmp_path, "evil.j2", {})
+
+
+def test_template_ssti_builtins(tmp_path):
+    env = create_template_env(tmp_path)
+    template_dir = tmp_path / "prompts" / "templates"
+    template_dir.mkdir(parents=True)
+
+    malicious_template = template_dir / "evil2.j2"
+    malicious_template.write_text("{{ ''.__class__.__mro__ }}")
+
+    with pytest.raises(SandboxedTemplateError, match="unsafe"):
+        render_template(tmp_path, "evil2.j2", {})
+
+
+def test_template_path_traversal(tmp_path):
+    with pytest.raises(Exception):
+        render_template(tmp_path, "../../../etc/passwd", {})
+
+
+def test_template_non_j2_extension(tmp_path):
+    with pytest.raises(Exception):
+        render_template(tmp_path, "setup.py", {})
+
+
+def test_template_normal_render(tmp_path):
+    template_dir = tmp_path / "prompts" / "templates"
+    template_dir.mkdir(parents=True)
+    template = template_dir / "test.j2"
+    template.write_text("Hello {{ name }}, issue #{{ number }}!")
+
+    result = render_template(tmp_path, "test.j2", {"name": "World", "number": 42})
+    assert result == "Hello World, issue #42!"

--- a/python/tests/test_milestone.py
+++ b/python/tests/test_milestone.py
@@ -1,0 +1,47 @@
+"""Tests for milestone mode — collection and plan parsing."""
+
+from pathlib import Path
+
+import pytest
+
+from railclaw_pipeline.milestone.collector import parse_plan_issues
+
+
+def test_parse_plan_issues_with_execution_order(tmp_path):
+    plan = tmp_path / "PLAN.md"
+    plan.write_text("""# Plan
+
+## Execution Order
+1. #65 — Fetch queue utility
+2. #72 — Rate limiter
+3. #78 — Cache invalidation
+
+## Phase 1
+Some content here
+""")
+    result = parse_plan_issues(plan)
+    assert result == [65, 72, 78]
+
+
+def test_parse_plan_issues_no_file(tmp_path):
+    plan = tmp_path / "nonexistent.md"
+    result = parse_plan_issues(plan)
+    assert result == []
+
+
+def test_parse_plan_issues_no_execution_order(tmp_path):
+    plan = tmp_path / "PLAN.md"
+    plan.write_text("# Plan\n\nJust a plan without execution order.\n")
+    result = parse_plan_issues(plan)
+    assert result == []
+
+
+def test_parse_plan_issues_deduplication(tmp_path):
+    plan = tmp_path / "PLAN.md"
+    plan.write_text("""## Execution Order
+1. #42 — First
+2. #42 — Duplicate
+3. #99 — Third
+""")
+    result = parse_plan_issues(plan)
+    assert result == [42, 99]

--- a/python/tests/test_persistence.py
+++ b/python/tests/test_persistence.py
@@ -1,0 +1,92 @@
+"""Tests for state persistence — atomic load/save."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from railclaw_pipeline.state.models import PipelineState, PipelineStage, PipelineStatus
+from railclaw_pipeline.state.persistence import load_state, save_state
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    return tmp_path / "state"
+
+
+@pytest.fixture
+def sample_state():
+    return PipelineState(issue_number=42, branch="feat/test", stage=PipelineStage.STAGE1_BLUEPRINT)
+
+
+def test_save_creates_file(state_dir, sample_state):
+    state_path = state_dir / "state.json"
+    save_state(sample_state, state_path)
+
+    assert state_path.exists()
+    data = json.loads(state_path.read_text())
+    assert data["issue_number"] == 42
+
+
+def test_load_returns_state(state_dir, sample_state):
+    state_path = state_dir / "state.json"
+    save_state(sample_state, state_path)
+
+    loaded = load_state(state_path)
+    assert loaded.issue_number == 42
+    assert loaded.branch == "feat/test"
+    assert loaded.stage == PipelineStage.STAGE1_BLUEPRINT
+
+
+def test_save_is_atomic(state_dir, sample_state):
+    state_path = state_dir / "state.json"
+
+    for i in range(10):
+        sample_state.issue_number = i + 100
+        save_state(sample_state, state_path)
+
+    loaded = load_state(state_path)
+    assert loaded.issue_number == 109
+
+
+def test_load_missing_file_raises(state_dir):
+    state_path = state_dir / "nonexistent.json"
+    with pytest.raises(FileNotFoundError):
+        load_state(state_path)
+
+
+def test_save_creates_parent_dirs(tmp_path, sample_state):
+    state_path = tmp_path / "deep" / "nested" / "dir" / "state.json"
+    save_state(sample_state, state_path)
+    assert state_path.exists()
+    loaded = load_state(state_path)
+    assert loaded.issue_number == 42
+
+
+def test_roundtrip_preserves_all_fields(state_dir):
+    from railclaw_pipeline.state.models import CycleState, Timestamps
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    state = PipelineState(
+        issue_number=7,
+        pr_number=12,
+        branch="feat/issue-7",
+        stage=PipelineStage.CYCLE2_GEMINI_LOOP,
+        status=PipelineStatus.RUNNING,
+        cycle=CycleState(cycle1_round=2, cycle2_round=5, gemini_clean=True, scope_verdict="pass"),
+        timestamps=Timestamps(started=now, stage_entered=now, last_updated=now),
+        findings={"current": [], "history": [{"severity": "medium", "description": "test"}]},
+    )
+
+    state_path = state_dir / "state.json"
+    save_state(state, state_path)
+    loaded = load_state(state_path)
+
+    assert loaded.issue_number == 7
+    assert loaded.pr_number == 12
+    assert loaded.cycle.cycle1_round == 2
+    assert loaded.cycle.gemini_clean is True
+    assert len(loaded.findings["history"]) == 1

--- a/python/tests/test_resume.py
+++ b/python/tests/test_resume.py
@@ -1,0 +1,129 @@
+"""Tests for resume — kill-and-resume scenarios."""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.state.models import (
+    CycleState,
+    PipelineStage,
+    PipelineState,
+    PipelineStatus,
+    Timestamps,
+)
+from railclaw_pipeline.state.persistence import load_state, save_state
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    return tmp_path / "state"
+
+
+@pytest.fixture
+def config(tmp_path):
+    return PipelineConfig({
+        "repoPath": str(tmp_path / "repo"),
+        "factoryPath": str(tmp_path / "factory"),
+    })
+
+
+def _make_state(stage: PipelineStage, **kwargs) -> PipelineState:
+    now = datetime.now(timezone.utc)
+    return PipelineState(
+        issue_number=42,
+        stage=stage,
+        status=PipelineStatus.RUNNING,
+        timestamps=Timestamps(started=now, stage_entered=now, last_updated=now),
+        **kwargs,
+    )
+
+
+def test_save_and_resume_at_stage2(state_dir):
+    state = _make_state(PipelineStage.STAGE2_WRENCH, branch="feat/test")
+    state_path = state_dir / "state.json"
+    save_state(state, state_path)
+
+    loaded = load_state(state_path)
+    assert loaded.stage == PipelineStage.STAGE2_WRENCH
+    assert loaded.branch == "feat/test"
+
+
+def test_resume_preserves_cycle_state(state_dir):
+    state = _make_state(
+        PipelineStage.STAGE5_FIX_LOOP,
+        cycle=CycleState(cycle1_round=2, cycle2_round=0, scope_verdict="revision"),
+    )
+    state_path = state_dir / "state.json"
+    save_state(state, state_path)
+
+    loaded = load_state(state_path)
+    assert loaded.cycle.cycle1_round == 2
+    assert loaded.cycle.scope_verdict == "revision"
+
+
+def test_resume_preserves_findings(state_dir):
+    findings = {
+        "current": [{"severity": "high", "description": "test finding"}],
+        "history": [{"severity": "medium", "description": "old finding"}],
+    }
+    state = _make_state(PipelineStage.STAGE4_REVIEW, findings=findings)
+    state_path = state_dir / "state.json"
+    save_state(state, state_path)
+
+    loaded = load_state(state_path)
+    assert len(loaded.findings["current"]) == 1
+    assert len(loaded.findings["history"]) == 1
+
+
+def test_resume_preserves_pr_number(state_dir):
+    state = _make_state(PipelineStage.CYCLE2_GEMINI_LOOP, pr_number=7, branch="feat/test")
+    state_path = state_dir / "state.json"
+    save_state(state, state_path)
+
+    loaded = load_state(state_path)
+    assert loaded.pr_number == 7
+
+
+def test_resume_after_interrupted_save(state_dir):
+    state_path = state_dir / "state.json"
+    state = _make_state(PipelineStage.STAGE8_APPROVAL, pr_number=12)
+    save_state(state, state_path)
+
+    loaded = load_state(state_path)
+    loaded.status = PipelineStatus.PAUSED
+    loaded.stage = PipelineStage.STAGE8_APPROVAL
+    save_state(loaded, state_path)
+
+    resumed = load_state(state_path)
+    assert resumed.status == PipelineStatus.PAUSED
+    assert resumed.stage == PipelineStage.STAGE8_APPROVAL
+    assert resumed.pr_number == 12
+
+
+def test_resume_milestone_mode(state_dir):
+    state = _make_state(
+        PipelineStage.STAGE1_BLUEPRINT,
+        milestone_mode=True,
+        milestone_label="v2.0",
+    )
+    state_path = state_dir / "state.json"
+    save_state(state, state_path)
+
+    loaded = load_state(state_path)
+    assert loaded.milestone_mode is True
+    assert loaded.milestone_label == "v2.0"
+
+
+def test_resume_error_state(state_dir):
+    state = _make_state(PipelineStage.STAGE2_WRENCH)
+    state.status = PipelineStatus.FAILED
+    state.error = {"category": "timeout", "message": "Stage timed out"}
+    state_path = state_dir / "state.json"
+    save_state(state, state_path)
+
+    loaded = load_state(state_path)
+    assert loaded.status == PipelineStatus.FAILED
+    assert loaded.error["category"] == "timeout"

--- a/python/tests/test_review_parsing.py
+++ b/python/tests/test_review_parsing.py
@@ -1,0 +1,55 @@
+"""Tests for review parsing and gemini polling helpers."""
+
+from railclaw_pipeline.github.review import parse_details_blocks, ReviewFinding
+
+
+def test_parse_details_blocks_empty():
+    assert parse_details_blocks("") == []
+
+
+def test_parse_details_blocks_single():
+    body = (
+        '<details><summary>High: Missing error handling</summary>\n'
+        'The function does not handle null values.\n'
+        '</details>'
+    )
+    findings = parse_details_blocks(body)
+    assert len(findings) == 1
+    assert findings[0].severity == "High"
+    assert findings[0].title == "Missing error handling"
+    assert "null values" in findings[0].description
+
+
+def test_parse_details_blocks_multiple():
+    body = (
+        '<details><summary>High: Bug A</summary>\nDesc A\n</details>\n'
+        '<details><summary>Medium: Suggestion B</summary>\nDesc B\n</details>\n'
+        '<details><summary>Low: Polish C</summary>\nDesc C\n</details>'
+    )
+    findings = parse_details_blocks(body)
+    assert len(findings) == 3
+    assert findings[0].severity == "High"
+    assert findings[1].severity == "Medium"
+    assert findings[2].severity == "Low"
+
+
+def test_parse_details_blocks_no_summary():
+    body = '<details>\nSome content without summary\n</details>'
+    findings = parse_details_blocks(body)
+    assert len(findings) == 0
+
+
+def test_review_finding_to_dict():
+    finding = ReviewFinding(
+        severity="HIGH",
+        title="Test finding",
+        description="Test description",
+        category="completeness",
+        file="test.py",
+        line=42,
+    )
+    d = finding.to_dict()
+    assert d["severity"] == "HIGH"
+    assert d["title"] == "Test finding"
+    assert d["file"] == "test.py"
+    assert d["line"] == 42

--- a/python/tests/test_stage5_fix_loop.py
+++ b/python/tests/test_stage5_fix_loop.py
@@ -1,0 +1,114 @@
+"""Tests for Stage 5 Fix Loop — Wrench fixes Scope review findings."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.runner.agent import AgentConfig, AgentResult
+from railclaw_pipeline.runner.subprocess_runner import AgentVerdict
+from railclaw_pipeline.state.models import CycleState, PipelineState, PipelineStage
+from railclaw_pipeline.stages.stage5_fix_loop import MAX_FIX_ROUNDS, _format_findings, run_fix_loop
+
+
+@pytest.fixture
+def config(tmp_path):
+    return PipelineConfig({
+        "repoPath": str(tmp_path / "repo"),
+        "factoryPath": str(tmp_path / "factory"),
+    })
+
+
+@pytest.fixture
+def emitter(tmp_path):
+    return EventEmitter(tmp_path / "events.jsonl")
+
+
+@pytest.fixture
+def state():
+    return PipelineState(
+        issue_number=42,
+        branch="feat/test",
+        stage=PipelineStage.STAGE5_FIX_LOOP,
+        cycle=CycleState(cycle1_round=0),
+        findings={"current": [{"severity": "high", "description": "fix this"}], "history": []},
+        timestamps=__import__("railclaw_pipeline.state.models", fromlist=["Timestamps"]).Timestamps(
+            started=datetime.now(timezone.utc),
+            stage_entered=datetime.now(timezone.utc),
+            last_updated=datetime.now(timezone.utc),
+        ),
+    )
+
+
+def test_max_fix_rounds():
+    assert MAX_FIX_ROUNDS == 5
+
+
+def test_format_findings():
+    findings = [
+        {"severity": "high", "description": "Bug found", "category": "correctness"},
+        {"severity": "low", "description": "Style issue", "category": "polish"},
+    ]
+    result = _format_findings(findings)
+    assert "HIGH" in result
+    assert "Bug found" in result
+    assert "LOW" in result
+    assert "Style issue" in result
+
+
+def test_format_findings_empty():
+    assert _format_findings([]) == ""
+
+
+async def test_fix_loop_no_findings(config, emitter):
+    state = PipelineState(
+        issue_number=42,
+        findings={"current": [], "history": []},
+    )
+    runner = AsyncMock()
+    result_state = await run_fix_loop(state, config, emitter, runner)
+    runner.run.assert_not_called()
+
+
+async def test_fix_loop_success(config, emitter, state):
+    agent_result = AgentResult(
+        agent_name="wrench",
+        verdict=AgentVerdict.PASS,
+        stdout="RESULT_START\nstatus: success\nRESULT_END",
+        duration=5.0,
+    )
+    runner = AsyncMock()
+    runner.run = AsyncMock(return_value=agent_result)
+
+    with patch("railclaw_pipeline.stages.stage5_fix_loop.GitOperations") as MockGit:
+        mock_git = MockGit.return_value
+        mock_git.reset_hard = AsyncMock(return_value="")
+        mock_git.clean = AsyncMock(return_value="")
+
+        result = await run_fix_loop(state, config, emitter, runner)
+
+    assert result.findings["current"] == []
+    assert len(result.findings["history"]) == 1
+    runner.run.assert_called_once()
+
+
+async def test_fix_loop_failure_raises(config, emitter, state):
+    agent_result = AgentResult(
+        agent_name="wrench",
+        verdict=AgentVerdict.ERROR,
+        error="agent crashed",
+        stderr="traceback...",
+    )
+    runner = AsyncMock()
+    runner.run = AsyncMock(return_value=agent_result)
+
+    with patch("railclaw_pipeline.stages.stage5_fix_loop.GitOperations") as MockGit:
+        mock_git = MockGit.return_value
+        mock_git.reset_hard = AsyncMock(return_value="")
+        mock_git.clean = AsyncMock(return_value="")
+
+        with pytest.raises(RuntimeError, match="failed"):
+            await run_fix_loop(state, config, emitter, runner)

--- a/python/tests/test_stage_merge.py
+++ b/python/tests/test_stage_merge.py
@@ -1,0 +1,154 @@
+"""Tests for Stage 8c: Merge — merge execution and branch cleanup."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.github.pr import PrError
+from railclaw_pipeline.state.models import PipelineState, PipelineStage
+from railclaw_pipeline.stages.stage8c_merge import run_merge
+
+
+@pytest.fixture
+def repo_dir(tmp_path):
+    return tmp_path / "repo"
+
+
+@pytest.fixture
+def factory_dir(tmp_path):
+    return tmp_path / "factory"
+
+
+@pytest.fixture
+def config(repo_dir, factory_dir):
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".pipeline-state").mkdir(parents=True, exist_ok=True)
+    return PipelineConfig({
+        "repoPath": str(repo_dir),
+        "factoryPath": str(factory_dir),
+    })
+
+
+@pytest.fixture
+def emitter(tmp_path):
+    return EventEmitter(tmp_path / "events.jsonl")
+
+
+def _make_state(pr_number=10, branch="feat/issue-42-add-feature"):
+    return PipelineState(
+        issue_number=42,
+        pr_number=pr_number,
+        stage=PipelineStage.STAGE8C_MERGE,
+        branch=branch,
+        timestamps=__import__("railclaw_pipeline.state.models", fromlist=["Timestamps"]).Timestamps(
+            started=datetime.now(timezone.utc),
+            stage_entered=datetime.now(timezone.utc),
+            last_updated=datetime.now(timezone.utc),
+        ),
+    )
+
+
+async def test_merge_no_pr_number(config, emitter):
+    state = _make_state(pr_number=None)
+    with pytest.raises(RuntimeError, match="No PR number"):
+        await run_merge(state, config, emitter)
+
+
+async def test_merge_not_mergeable_after_retries(config, emitter):
+    state = _make_state()
+
+    with (
+        patch("railclaw_pipeline.stages.stage8c_merge.PrClient") as MockPr,
+        patch("railclaw_pipeline.stages.stage8c_merge.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        mock_pr = MockPr.return_value
+        mock_pr.is_mergeable = AsyncMock(return_value=(False, "DIRTY"))
+        with pytest.raises(RuntimeError, match="not mergeable"):
+            await run_merge(state, config, emitter)
+
+
+async def test_merge_success_with_branch_cleanup(config, emitter):
+    state = _make_state()
+
+    with (
+        patch("railclaw_pipeline.stages.stage8c_merge.PrClient") as MockPr,
+        patch("railclaw_pipeline.stages.stage8c_merge.GitOperations") as MockGit,
+    ):
+        mock_pr = MockPr.return_value
+        mock_pr.is_mergeable = AsyncMock(return_value=(True, "CLEAN"))
+        mock_pr.merge = AsyncMock(return_value="sha123")
+
+        mock_git = MockGit.return_value
+        mock_git.checkout = AsyncMock(return_value="main")
+        mock_git.pull = AsyncMock(return_value="Already up to date.")
+        mock_git.delete_branch = AsyncMock(return_value=None)
+        mock_git.delete_remote_branch = AsyncMock(return_value=None)
+
+        result = await run_merge(state, config, emitter)
+
+    mock_git.delete_branch.assert_called_once_with("feat/issue-42-add-feature", force=True)
+    mock_git.delete_remote_branch.assert_called_once_with("feat/issue-42-add-feature")
+    assert result.timestamps.stage_entered is not None
+
+
+async def test_merge_success_branch_cleanup_fails_gracefully(config, emitter):
+    state = _make_state()
+
+    with (
+        patch("railclaw_pipeline.stages.stage8c_merge.PrClient") as MockPr,
+        patch("railclaw_pipeline.stages.stage8c_merge.GitOperations") as MockGit,
+    ):
+        mock_pr = MockPr.return_value
+        mock_pr.is_mergeable = AsyncMock(return_value=(True, "CLEAN"))
+        mock_pr.merge = AsyncMock(return_value="sha123")
+
+        mock_git = MockGit.return_value
+        mock_git.checkout = AsyncMock(return_value="main")
+        mock_git.pull = AsyncMock(return_value="Already up to date.")
+        mock_git.delete_branch = AsyncMock(side_effect=Exception("branch not found"))
+        mock_git.delete_remote_branch = AsyncMock(side_effect=Exception("remote error"))
+
+        result = await run_merge(state, config, emitter)
+
+    assert result.timestamps.stage_entered is not None
+
+
+async def test_merge_failure_raises(config, emitter):
+    state = _make_state()
+
+    with patch("railclaw_pipeline.stages.stage8c_merge.PrClient") as MockPr:
+        mock_pr = MockPr.return_value
+        mock_pr.is_mergeable = AsyncMock(return_value=(True, "CLEAN"))
+        mock_pr.merge = AsyncMock(side_effect=PrError("merge conflict"))
+
+        with pytest.raises(RuntimeError, match="Failed to merge PR"):
+            await run_merge(state, config, emitter)
+
+
+async def test_merge_becomes_mergeable_after_retry(config, emitter):
+    state = _make_state()
+
+    with (
+        patch("railclaw_pipeline.stages.stage8c_merge.PrClient") as MockPr,
+        patch("railclaw_pipeline.stages.stage8c_merge.GitOperations") as MockGit,
+        patch("railclaw_pipeline.stages.stage8c_merge.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        mock_pr = MockPr.return_value
+        mock_pr.is_mergeable = AsyncMock(
+            side_effect=[(False, "BLOCKED"), (False, "BLOCKED"), (True, "CLEAN")]
+        )
+        mock_pr.merge = AsyncMock(return_value="sha456")
+
+        mock_git = MockGit.return_value
+        mock_git.checkout = AsyncMock(return_value="main")
+        mock_git.pull = AsyncMock(return_value="Already up to date.")
+        mock_git.delete_branch = AsyncMock(return_value=None)
+        mock_git.delete_remote_branch = AsyncMock(return_value=None)
+
+        result = await run_merge(state, config, emitter)
+
+    assert result.timestamps.stage_entered is not None

--- a/python/tests/test_stage_pr.py
+++ b/python/tests/test_stage_pr.py
@@ -1,0 +1,114 @@
+"""Tests for Stage 2.5: PR creation — idempotency and error handling."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.state.models import PipelineState, PipelineStage
+from railclaw_pipeline.stages.stage2_5_pr import run_create_pr
+
+
+@pytest.fixture
+def repo_dir(tmp_path):
+    return tmp_path / "repo"
+
+
+@pytest.fixture
+def factory_dir(tmp_path):
+    return tmp_path / "factory"
+
+
+@pytest.fixture
+def config(repo_dir, factory_dir):
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    (factory_dir / ".pipeline-state").mkdir(parents=True, exist_ok=True)
+    return PipelineConfig({
+        "repoPath": str(repo_dir),
+        "factoryPath": str(factory_dir),
+    })
+
+
+@pytest.fixture
+def emitter(tmp_path):
+    return EventEmitter(tmp_path / "events.jsonl")
+
+
+@pytest.fixture
+def state():
+    return PipelineState(
+        issue_number=42,
+        stage=PipelineStage.STAGE2_5_CREATE_PR,
+        branch="feat/issue-42-add-feature",
+        timestamps=__import__("railclaw_pipeline.state.models", fromlist=["Timestamps"]).Timestamps(
+            started=datetime.now(timezone.utc),
+            stage_entered=datetime.now(timezone.utc),
+            last_updated=datetime.now(timezone.utc),
+        ),
+    )
+
+
+async def test_create_pr_no_branch(config, emitter):
+    state = PipelineState(
+        issue_number=42,
+        stage=PipelineStage.STAGE2_5_CREATE_PR,
+        timestamps=__import__("railclaw_pipeline.state.models", fromlist=["Timestamps"]).Timestamps(
+            started=datetime.now(timezone.utc),
+            stage_entered=datetime.now(timezone.utc),
+            last_updated=datetime.now(timezone.utc),
+        ),
+    )
+    with pytest.raises(RuntimeError, match="No branch set"):
+        await run_create_pr(state, config, emitter)
+
+
+async def test_create_pr_already_exists(config, emitter, state):
+    existing_pr = {"number": 99, "title": "Existing PR", "state": "OPEN"}
+
+    with patch("railclaw_pipeline.stages.stage2_5_pr.PrClient") as MockPr:
+        mock_pr = MockPr.return_value
+        mock_pr.find_by_head = AsyncMock(return_value=existing_pr)
+        result = await run_create_pr(state, config, emitter)
+
+    assert result.pr_number == 99
+
+
+async def test_create_pr_success(config, emitter, state):
+    with patch("railclaw_pipeline.stages.stage2_5_pr.PrClient") as MockPr:
+        mock_pr = MockPr.return_value
+        mock_pr.find_by_head = AsyncMock(return_value=None)
+        mock_pr.create = AsyncMock(return_value={"pr_number": 7, "url": "https://github.com/test/repo/pull/7"})
+        result = await run_create_pr(state, config, emitter)
+
+    assert result.pr_number == 7
+
+
+async def test_create_pr_parse_url(config, emitter, state):
+    with patch("railclaw_pipeline.stages.stage2_5_pr.PrClient") as MockPr:
+        mock_pr = MockPr.return_value
+        mock_pr.find_by_head = AsyncMock(return_value=None)
+        mock_pr.create = AsyncMock(return_value={"url": "https://github.com/test/repo/pull/123"})
+        result = await run_create_pr(state, config, emitter)
+
+    assert result.pr_number == 123
+
+
+async def test_create_pr_no_number_no_url(config, emitter, state):
+    with patch("railclaw_pipeline.stages.stage2_5_pr.PrClient") as MockPr:
+        mock_pr = MockPr.return_value
+        mock_pr.find_by_head = AsyncMock(return_value=None)
+        mock_pr.create = AsyncMock(return_value={"url": "https://github.com/test/repo/commits/main"})
+        with pytest.raises(RuntimeError, match="no number"):
+            await run_create_pr(state, config, emitter)
+
+
+async def test_create_pr_empty_result(config, emitter, state):
+    with patch("railclaw_pipeline.stages.stage2_5_pr.PrClient") as MockPr:
+        mock_pr = MockPr.return_value
+        mock_pr.find_by_head = AsyncMock(return_value=None)
+        mock_pr.create = AsyncMock(return_value={})
+        with pytest.raises(RuntimeError, match="no number"):
+            await run_create_pr(state, config, emitter)

--- a/python/tests/test_stage_preflight.py
+++ b/python/tests/test_stage_preflight.py
@@ -1,0 +1,107 @@
+"""Tests for Stage 0 Preflight — environment readiness checks."""
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from railclaw_pipeline.config import PipelineConfig
+from railclaw_pipeline.events.emitter import EventEmitter
+from railclaw_pipeline.state.models import PipelineState, PipelineStage
+from railclaw_pipeline.stages.stage0_preflight import PreflightError, run_preflight
+
+
+@pytest.fixture
+def repo_dir(tmp_path):
+    return tmp_path / "repo"
+
+
+@pytest.fixture
+def factory_dir(tmp_path):
+    return tmp_path / "factory"
+
+
+@pytest.fixture
+def config(repo_dir, factory_dir):
+    factory_dir.mkdir(parents=True, exist_ok=True)
+    return PipelineConfig({
+        "repoPath": str(repo_dir),
+        "factoryPath": str(factory_dir),
+    })
+
+
+@pytest.fixture
+def emitter(tmp_path):
+    return EventEmitter(tmp_path / "events.jsonl")
+
+
+@pytest.fixture
+def state():
+    return PipelineState(
+        issue_number=42,
+        stage=PipelineStage.STAGE0_PREFLIGHT,
+        timestamps=__import__("railclaw_pipeline.state.models", fromlist=["Timestamps"]).Timestamps(
+            started=datetime.now(timezone.utc),
+            stage_entered=datetime.now(timezone.utc),
+            last_updated=datetime.now(timezone.utc),
+        ),
+    )
+
+
+def test_preflight_error_is_exception():
+    err = PreflightError("test error")
+    assert str(err) == "test error"
+    assert isinstance(err, Exception)
+
+
+async def test_preflight_missing_repo(config, emitter, state):
+    with pytest.raises(PreflightError, match="does not exist"):
+        await run_preflight(state, config, emitter)
+
+
+async def test_preflight_wrong_branch(repo_dir, config, emitter, state):
+    repo_dir.mkdir(parents=True)
+    (repo_dir / ".git").mkdir()
+
+    with patch("railclaw_pipeline.stages.stage0_preflight.GitOperations") as MockGit:
+        mock_git = MockGit.return_value
+        mock_git.current_branch = AsyncMock(return_value="develop")
+        with pytest.raises(PreflightError, match="Not on main branch"):
+            await run_preflight(state, config, emitter)
+
+
+async def test_preflight_dirty_tree(repo_dir, config, emitter, state):
+    repo_dir.mkdir(parents=True)
+    (repo_dir / ".git").mkdir()
+
+    with patch("railclaw_pipeline.stages.stage0_preflight.GitOperations") as MockGit:
+        mock_git = MockGit.return_value
+        mock_git.current_branch = AsyncMock(return_value="main")
+        mock_git.is_dirty = AsyncMock(return_value=True)
+        with pytest.raises(PreflightError, match="not clean"):
+            await run_preflight(state, config, emitter)
+
+
+async def test_preflight_missing_factory(repo_dir, emitter, state):
+    config = PipelineConfig({
+        "repoPath": str(repo_dir),
+        "factoryPath": str(repo_dir / "nonexistent_factory"),
+    })
+    repo_dir.mkdir(parents=True)
+    (repo_dir / ".git").mkdir()
+
+    with patch("railclaw_pipeline.stages.stage0_preflight.GitOperations") as MockGit:
+        mock_git = MockGit.return_value
+        mock_git.current_branch = AsyncMock(return_value="main")
+        mock_git.is_dirty = AsyncMock(return_value=False)
+        mock_git.fetch = AsyncMock(return_value="")
+        mock_git.pull = AsyncMock(return_value="")
+        with patch("asyncio.create_subprocess_exec") as mock_proc:
+            mock_p = AsyncMock()
+            mock_p.communicate = AsyncMock(return_value=(b"", b""))
+            mock_p.returncode = 0
+            mock_proc.return_value = mock_p
+            with pytest.raises(PreflightError, match="factory"):
+                await run_preflight(state, config, emitter)

--- a/python/tests/test_state_models.py
+++ b/python/tests/test_state_models.py
@@ -1,0 +1,84 @@
+"""Tests for pipeline state models."""
+
+import json
+from datetime import datetime, timezone
+
+from railclaw_pipeline.state.models import (
+    CycleState,
+    PipelineStage,
+    PipelineState,
+    PipelineStatus,
+    Timestamps,
+)
+
+
+def test_pipeline_stage_values():
+    assert PipelineStage.IDLE == "idle"
+    assert PipelineStage.STAGE0_PREFLIGHT == "stage0_preflight"
+    assert PipelineStage.STAGE12_LESSONS == "stage12_lessons"
+
+
+def test_pipeline_status_values():
+    assert PipelineStatus.RUNNING == "running"
+    assert PipelineStatus.PAUSED == "paused"
+    assert PipelineStatus.COMPLETED == "completed"
+    assert PipelineStatus.FAILED == "failed"
+
+
+def test_pipeline_state_defaults():
+    state = PipelineState(issue_number=42)
+    assert state.issue_number == 42
+    assert state.pr_number is None
+    assert state.stage == PipelineStage.IDLE
+    assert state.status == PipelineStatus.RUNNING
+    assert state.milestone_mode is False
+    assert state.cycle.cycle1_round == 0
+    assert state.cycle.cycle2_round == 0
+    assert state.cycle.scope_verdict == ""
+    assert state.cycle.gemini_clean is False
+    assert state.error is None
+
+
+def test_pipeline_state_serialization():
+    now = datetime.now(timezone.utc)
+    state = PipelineState(
+        issue_number=42,
+        pr_number=7,
+        branch="feat/test",
+        stage=PipelineStage.STAGE2_WRENCH,
+        status=PipelineStatus.RUNNING,
+        timestamps=Timestamps(started=now, stage_entered=now, last_updated=now),
+        findings={"current": [{"severity": "high", "description": "test"}], "history": []},
+    )
+
+    data = state.model_dump(mode="json")
+    assert data["issue_number"] == 42
+    assert data["pr_number"] == 7
+    assert data["stage"] == "stage2_wrench"
+    assert data["findings"]["current"][0]["severity"] == "high"
+
+    restored = PipelineState.model_validate(data)
+    assert restored.issue_number == 42
+    assert restored.branch == "feat/test"
+    assert restored.findings["current"][0]["severity"] == "high"
+
+
+def test_cycle_state_defaults():
+    cycle = CycleState()
+    assert cycle.cycle1_round == 0
+    assert cycle.gemini_clean is False
+
+
+def test_pipeline_state_json_roundtrip():
+    state = PipelineState(
+        issue_number=99,
+        stage=PipelineStage.STAGE8_APPROVAL,
+        status=PipelineStatus.PAUSED,
+        cycle=CycleState(cycle1_round=3, gemini_clean=True),
+    )
+    json_str = state.model_dump_json()
+    restored = PipelineState.model_validate_json(json_str)
+    assert restored.issue_number == 99
+    assert restored.status == PipelineStatus.PAUSED
+    assert restored.cycle.cycle1_round == 3
+    assert restored.cycle.gemini_clean is True

--- a/python/tests/test_subprocess_runner.py
+++ b/python/tests/test_subprocess_runner.py
@@ -1,0 +1,103 @@
+"""Tests for subprocess runner — async subprocess wrappers."""
+
+import asyncio
+
+import pytest
+
+from railclaw_pipeline.runner.subprocess_runner import (
+    AgentVerdict,
+    SubprocessError,
+    SubprocessResult,
+    parse_verdict,
+    run_subprocess,
+    run_subprocess_safe,
+)
+
+
+def test_subprocess_result_defaults():
+    result = SubprocessResult()
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert result.returncode == -1
+    assert result.duration == 0.0
+    assert result.timed_out is False
+    assert result.killed is False
+    assert result.success is False
+
+
+def test_subprocess_result_success():
+    result = SubprocessResult(returncode=0)
+    assert result.success is True
+
+
+def test_subprocess_result_timeout_not_success():
+    result = SubprocessResult(returncode=0, timed_out=True)
+    assert result.success is False
+
+
+async def test_run_subprocess_echo():
+    result = await run_subprocess(["echo", "hello"], timeout=10)
+    assert result.stdout.strip() == "hello"
+    assert result.returncode == 0
+
+
+async def test_run_subprocess_cwd(tmp_path):
+    (tmp_path / "test.txt").write_text("found")
+    result = await run_subprocess(["cat", "test.txt"], cwd=tmp_path, timeout=10)
+    assert result.stdout.strip() == "found"
+
+
+async def test_run_subprocess_timeout():
+    with pytest.raises(SubprocessError, match="timed out"):
+        await run_subprocess(["sleep", "10"], timeout=0.1)
+
+
+async def test_run_subprocess_nonzero_exit():
+    with pytest.raises(SubprocessError):
+        await run_subprocess(["false"], timeout=10)
+
+
+async def test_run_subprocess_empty_command():
+    with pytest.raises(SubprocessError, match="Empty command"):
+        await run_subprocess([])
+
+
+async def test_run_subprocess_missing_binary():
+    with pytest.raises(SubprocessError, match="Failed to start"):
+        await run_subprocess(["nonexistent_binary_xyz_123"], timeout=5)
+
+
+async def test_run_subprocess_safe_returns_result():
+    result = await run_subprocess_safe(["echo", "safe"], timeout=10)
+    assert result.stdout.strip() == "safe"
+
+
+async def test_run_subprocess_safe_handles_failure():
+    result = await run_subprocess_safe(["false"], timeout=10)
+    assert result.returncode == -1
+
+
+async def test_run_subprocess_with_env():
+    result = await run_subprocess(
+        ["env"],
+        env={"RAILCLAW_TEST_VAR": "test_value_123"},
+        timeout=10,
+    )
+    assert "test_value_123" in result.stdout
+
+
+async def test_run_subprocess_with_input():
+    result = await run_subprocess(
+        ["cat"],
+        input_text="hello from stdin",
+        timeout=10,
+    )
+    assert "hello from stdin" in result.stdout
+
+
+def test_parse_verdict_all_status_types():
+    assert parse_verdict("RESULT_START\nstatus: success\nRESULT_END") == AgentVerdict.PASS
+    assert parse_verdict("RESULT_START\nstatus: failure\nRESULT_END") == AgentVerdict.REVISION
+    assert parse_verdict("RESULT_START\nstatus: needs-human\nRESULT_END") == AgentVerdict.NEEDS_HUMAN
+    assert parse_verdict("RESULT_START\nstatus: timeout\nRESULT_END") == AgentVerdict.TIMEOUT
+    assert parse_verdict("RESULT_START\nstatus: error\nRESULT_END") == AgentVerdict.ERROR

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Postinstall script: Install Python package in development mode
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_DIR="$(dirname "$SCRIPT_DIR")/python"
+
+if [ -d "$PYTHON_DIR" ]; then
+    echo "Installing Python package in development mode..."
+    cd "$PYTHON_DIR"
+    pip install -e .
+    echo "Python package installed successfully."
+else
+    echo "Python directory not found at $PYTHON_DIR"
+    exit 1
+fi

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,86 @@
+import type { Static } from "@sinclair/typebox";
+import type { PipelineRunParameters } from "./tool.js";
+
+export interface PluginConfig {
+  repoPath: string;
+  factoryPath: string;
+  pythonCommand: string;
+  stateDir: string;
+  eventsDir: string;
+  agents: {
+    blueprint: { model: string; timeout: number };
+    wrench: { model: string; timeout: number };
+    scope: { model: string; timeout: number };
+    beaker: { model: string; timeout: number };
+    wrenchSr: { model: string; timeout: number };
+  };
+  timing: {
+    geminiPollInterval: number;
+    approvalTimeout: number;
+    healthCheckTimeout: number;
+  };
+  pm2: {
+    processName: string;
+    ecosystemPath: string;
+  };
+  escalation: {
+    wrenchSrAfterRound: number;
+    chrisAfterRound: number;
+  };
+}
+
+export type PipelineRunParams = Static<typeof PipelineRunParameters>;
+
+const DEFAULT_CONFIG: PluginConfig = {
+  repoPath: "/home/chris/.openclaw/agents/railrunner/workspace/repos/RailClaw",
+  factoryPath: "/home/chris/.openclaw/agents/railrunner/workspace/repos/RailClaw/factory",
+  pythonCommand: "railclaw-pipeline",
+  stateDir: ".pipeline-state",
+  eventsDir: ".pipeline-events",
+  agents: {
+    blueprint: { model: "openai/gpt-5.4", timeout: 600 },
+    wrench: { model: "zai/glm-5-turbo", timeout: 1200 },
+    scope: { model: "minimax/MiniMax-M2.7", timeout: 600 },
+    beaker: { model: "openai/gpt-5.4-mini", timeout: 600 },
+    wrenchSr: { model: "gemini/gemini-3.1-pro-preview", timeout: 1200 },
+  },
+  timing: {
+    geminiPollInterval: 60,
+    approvalTimeout: 86400,
+    healthCheckTimeout: 30,
+  },
+  pm2: {
+    processName: "railclaw-mc",
+    ecosystemPath: "ecosystem.config.cjs",
+  },
+  escalation: {
+    wrenchSrAfterRound: 3,
+    chrisAfterRound: 5,
+  },
+};
+
+export function normalizeConfig(userConfig: Record<string, unknown>): PluginConfig {
+  return {
+    repoPath: typeof userConfig.repoPath === "string" ? userConfig.repoPath : DEFAULT_CONFIG.repoPath,
+    factoryPath: typeof userConfig.factoryPath === "string" ? userConfig.factoryPath : DEFAULT_CONFIG.factoryPath,
+    pythonCommand: typeof userConfig.pythonCommand === "string" ? userConfig.pythonCommand : DEFAULT_CONFIG.pythonCommand,
+    stateDir: typeof userConfig.stateDir === "string" ? userConfig.stateDir : DEFAULT_CONFIG.stateDir,
+    eventsDir: typeof userConfig.eventsDir === "string" ? userConfig.eventsDir : DEFAULT_CONFIG.eventsDir,
+    agents: {
+      ...DEFAULT_CONFIG.agents,
+      ...(typeof userConfig.agents === "object" && userConfig.agents !== null ? userConfig.agents : {}),
+    } as PluginConfig["agents"],
+    timing: {
+      ...DEFAULT_CONFIG.timing,
+      ...(typeof userConfig.timing === "object" && userConfig.timing !== null ? userConfig.timing : {}),
+    } as PluginConfig["timing"],
+    pm2: {
+      ...DEFAULT_CONFIG.pm2,
+      ...(typeof userConfig.pm2 === "object" && userConfig.pm2 !== null ? userConfig.pm2 : {}),
+    } as PluginConfig["pm2"],
+    escalation: {
+      ...DEFAULT_CONFIG.escalation,
+      ...(typeof userConfig.escalation === "object" && userConfig.escalation !== null ? userConfig.escalation : {}),
+    } as PluginConfig["escalation"],
+  };
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,7 @@
+export function registerLifecycleHooks(api: {
+  on: (event: string, handler: () => void | Promise<void>) => void;
+}): void {
+  api.on("shutdown", async () => {
+    console.log("[railclaw-pipeline] Plugin shutting down");
+  });
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,7 +1,31 @@
+import { pipelineStore } from "./store.js";
+
 export function registerLifecycleHooks(api: {
   on: (event: string, handler: () => void | Promise<void>) => void;
 }): void {
+  api.on("startup", async () => {
+    try {
+      const keys = pipelineStore.keys();
+      for (const key of keys) {
+        const meta = pipelineStore.get(key);
+        if (meta && meta.status === "running") {
+          pipelineStore.set(key, {
+            ...meta,
+            status: "interrupted",
+            updatedAt: new Date().toISOString(),
+          });
+        }
+      }
+    } catch {
+      // Store cleanup is advisory
+    }
+  });
+
   api.on("shutdown", async () => {
-    console.log("[railclaw-pipeline] Plugin shutting down");
+    try {
+      pipelineStore.clear();
+    } catch {
+      // Non-critical
+    }
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,14 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { registerPipelineTool } from "./tool.js";
+import { normalizeConfig } from "./config.js";
+
+export default definePluginEntry({
+  id: "railclaw-pipeline",
+  name: "RailClaw Pipeline Orchestrator",
+  description: "Automated coding factory pipeline: planning → implementation → review → merge → deploy → QA",
+  version: "0.1.0",
+  register(api) {
+    const config = normalizeConfig(api.pluginConfig);
+    registerPipelineTool(api, config);
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { registerPipelineTool } from "./tool.js";
 import { normalizeConfig } from "./config.js";
+import { registerLifecycleHooks } from "./hooks.js";
 
 export default definePluginEntry({
   id: "railclaw-pipeline",
@@ -10,5 +11,6 @@ export default definePluginEntry({
   register(api) {
     const config = normalizeConfig(api.pluginConfig);
     registerPipelineTool(api, config);
+    registerLifecycleHooks(api);
   },
 });

--- a/src/python-bridge.ts
+++ b/src/python-bridge.ts
@@ -1,0 +1,88 @@
+import { spawn, ChildProcess } from "child_process";
+import type { PluginConfig, PipelineRunParams } from "./config.js";
+
+export interface PythonBridgeResult {
+  ok: boolean;
+  action: string;
+  stage?: string;
+  status?: string;
+  issueNumber?: number;
+  prNumber?: number;
+  branch?: string;
+  message?: string;
+  statePath?: string;
+  error?: string | null;
+}
+
+export function spawnPythonBridge(
+  config: PluginConfig,
+  params: PipelineRunParams
+): Promise<PythonBridgeResult> {
+  return new Promise((resolve) => {
+    const args: string[] = [params.action];
+
+    if (params.issueNumber !== undefined) {
+      args.push("--issue", params.issueNumber.toString());
+    }
+    if (params.milestone !== undefined) {
+      args.push("--milestone", params.milestone);
+    }
+    if (params.hotfix !== undefined && params.hotfix) {
+      args.push("--hotfix");
+    }
+    if (params.forceStage !== undefined) {
+      args.push("--force-stage", params.forceStage);
+    }
+
+    const proc = spawn(config.pythonCommand, args, {
+      cwd: config.repoPath,
+      env: {
+        ...process.env,
+        RAILCLAW_FACTORY_PATH: config.factoryPath,
+        RAILCLAW_STATE_DIR: config.stateDir,
+        RAILCLAW_EVENTS_DIR: config.eventsDir,
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    proc.stdout.on("data", (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr.on("data", (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on("close", (code) => {
+      if (code !== 0) {
+        resolve({
+          ok: false,
+          action: params.action,
+          error: `Python process exited with code ${code}: ${stderr}`,
+        });
+        return;
+      }
+
+      try {
+        const result = JSON.parse(stdout.trim()) as PythonBridgeResult;
+        resolve(result);
+      } catch (error) {
+        resolve({
+          ok: false,
+          action: params.action,
+          error: `Failed to parse Python output: ${error instanceof Error ? error.message : String(error)}`,
+        });
+      }
+    });
+
+    proc.on("error", (error) => {
+      resolve({
+        ok: false,
+        action: params.action,
+        error: `Failed to spawn Python process: ${error.message}`,
+      });
+    });
+  });
+}

--- a/src/python-bridge.ts
+++ b/src/python-bridge.ts
@@ -1,5 +1,6 @@
-import { spawn, ChildProcess } from "child_process";
+import { spawn } from "child_process";
 import type { PluginConfig, PipelineRunParams } from "./config.js";
+import { pipelineStore } from "./store.js";
 
 export interface PythonBridgeResult {
   ok: boolean;
@@ -41,6 +42,7 @@ export function spawnPythonBridge(
         RAILCLAW_FACTORY_PATH: config.factoryPath,
         RAILCLAW_STATE_DIR: config.stateDir,
         RAILCLAW_EVENTS_DIR: config.eventsDir,
+        RAILCLAW_REPO_PATH: config.repoPath,
       },
     });
 
@@ -67,6 +69,22 @@ export function spawnPythonBridge(
 
       try {
         const result = JSON.parse(stdout.trim()) as PythonBridgeResult;
+
+        if (result.ok && result.issueNumber && result.stage) {
+          try {
+            pipelineStore.set(`run:${result.issueNumber}`, {
+              issueNumber: result.issueNumber,
+              stage: result.stage,
+              status: result.status ?? "running",
+              startedAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              statePath: result.statePath ?? "",
+            });
+          } catch {
+            // Store is advisory — failures are non-critical
+          }
+        }
+
         resolve(result);
       } catch (error) {
         resolve({

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,12 @@
+import { createPluginRuntimeStore } from "openclaw/plugin-sdk/runtime-store";
+
+export interface PipelineRunMetadata {
+  issueNumber: number;
+  stage: string;
+  status: string;
+  startedAt: string;
+  updatedAt: string;
+  statePath: string;
+}
+
+export const pipelineStore = createPluginRuntimeStore<PipelineRunMetadata>("railclaw-pipeline");

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,0 +1,63 @@
+import { Type, Static } from "@sinclair/typebox";
+import { spawnPythonBridge } from "./python-bridge.js";
+import type { PluginConfig } from "./config.js";
+
+const PipelineRunParameters = Type.Object({
+  action: Type.Union([
+    Type.Literal("run"),
+    Type.Literal("status"),
+    Type.Literal("resume"),
+    Type.Literal("abort"),
+  ]),
+  issueNumber: Type.Optional(Type.Number()),
+  milestone: Type.Optional(Type.String()),
+  hotfix: Type.Optional(Type.Boolean()),
+  forceStage: Type.Optional(Type.String()),
+  waitForCompletion: Type.Optional(Type.Boolean()),
+});
+
+type PipelineRunParams = Static<typeof PipelineRunParameters>;
+
+export function registerPipelineTool(
+  api: {
+    registerTool: (tool: {
+      name: string;
+      description: string;
+      parameters: typeof PipelineRunParameters;
+      execute: (id: string, params: PipelineRunParams) => Promise<{ content: Array<{ type: string; text: string }> }>;
+    }) => void;
+  },
+  config: PluginConfig
+) {
+  api.registerTool({
+    name: "pipeline_run",
+    description: "Run the coding factory pipeline for an issue or milestone",
+    parameters: PipelineRunParameters,
+    async execute(_id: string, params: PipelineRunParams) {
+      if (params.action === "run" && !params.issueNumber && !params.milestone) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                ok: false,
+                error: "issueNumber or milestone is required for run action",
+              }),
+            },
+          ],
+        };
+      }
+
+      const result = await spawnPythonBridge(config, params);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(result),
+          },
+        ],
+      };
+    },
+  });
+}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "@jest/globals";
+import { normalizeConfig } from "../src/config.js";
+
+describe("normalizeConfig", () => {
+  it("returns defaults for empty input", () => {
+    const config = normalizeConfig({});
+    expect(config.repoPath).toBeDefined();
+    expect(config.factoryPath).toBeDefined();
+    expect(config.pythonCommand).toBe("railclaw-pipeline");
+    expect(config.stateDir).toBe(".pipeline-state");
+    expect(config.eventsDir).toBe(".pipeline-events");
+  });
+
+  it("overrides provided string fields", () => {
+    const config = normalizeConfig({
+      repoPath: "/custom/repo",
+      factoryPath: "/custom/factory",
+      pythonCommand: "custom-cmd",
+      stateDir: "custom-state",
+      eventsDir: "custom-events",
+    });
+    expect(config.repoPath).toBe("/custom/repo");
+    expect(config.factoryPath).toBe("/custom/factory");
+    expect(config.pythonCommand).toBe("custom-cmd");
+    expect(config.stateDir).toBe("custom-state");
+    expect(config.eventsDir).toBe("custom-events");
+  });
+
+  it("merges agent config with defaults", () => {
+    const config = normalizeConfig({
+      agents: {
+        blueprint: { model: "custom-model", timeout: 999 },
+      },
+    });
+    expect(config.agents.blueprint.model).toBe("custom-model");
+    expect(config.agents.blueprint.timeout).toBe(999);
+    expect(config.agents.wrench.model).toBeDefined();
+  });
+
+  it("merges timing config with defaults", () => {
+    const config = normalizeConfig({
+      timing: { geminiPollInterval: 120 },
+    });
+    expect(config.timing.geminiPollInterval).toBe(120);
+    expect(config.timing.approvalTimeout).toBe(86400);
+  });
+
+  it("merges escalation config with defaults", () => {
+    const config = normalizeConfig({
+      escalation: { wrenchSrAfterRound: 5 },
+    });
+    expect(config.escalation.wrenchSrAfterRound).toBe(5);
+    expect(config.escalation.chrisAfterRound).toBe(5);
+  });
+
+  it("handles null nested objects", () => {
+    const config = normalizeConfig({
+      agents: null,
+      timing: null,
+    });
+    expect(config.agents.blueprint).toBeDefined();
+    expect(config.timing.geminiPollInterval).toBe(60);
+  });
+});

--- a/tests/plugin-entry.test.ts
+++ b/tests/plugin-entry.test.ts
@@ -1,0 +1,47 @@
+import { jest, describe, it, expect } from "@jest/globals";
+
+jest.mock("openclaw/plugin-sdk/plugin-entry", () => ({
+  definePluginEntry: (entry: any) => entry,
+}));
+
+jest.mock("openclaw/plugin-sdk/runtime-store", () => ({
+  createPluginRuntimeStore: () => ({
+    get: jest.fn(),
+    set: jest.fn(),
+    keys: jest.fn(() => []),
+    clear: jest.fn(),
+  }),
+}));
+
+const mockRegisterTool = jest.fn();
+const mockOn = jest.fn();
+const mockApi = {
+  pluginConfig: {
+    repoPath: "/test/repo",
+    factoryPath: "/test/factory",
+  },
+  registerTool: mockRegisterTool,
+  on: mockOn,
+};
+
+describe("plugin entry", () => {
+  it("exports a default entry with register function", async () => {
+    const entry = (await import("../src/index.js")).default;
+    expect(entry).toBeDefined();
+    expect(entry.id).toBe("railclaw-pipeline");
+    expect(entry.name).toBe("RailClaw Pipeline Orchestrator");
+    expect(typeof entry.register).toBe("function");
+  });
+
+  it("calls registerTool during register", async () => {
+    const entry = (await import("../src/index.js")).default;
+    entry.register(mockApi);
+    expect(mockRegisterTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers lifecycle hooks", async () => {
+    const entry = (await import("../src/index.js")).default;
+    entry.register(mockApi);
+    expect(mockOn).toHaveBeenCalled();
+  });
+});

--- a/tests/python-bridge.test.ts
+++ b/tests/python-bridge.test.ts
@@ -1,0 +1,85 @@
+import { jest, describe, it, expect } from "@jest/globals";
+
+jest.mock("openclaw/plugin-sdk/runtime-store", () => ({
+  createPluginRuntimeStore: () => {
+    const store = new Map<string, any>();
+    return {
+      get: (key: string) => store.get(key),
+      set: (key: string, value: any) => { store.set(key, value); },
+      keys: () => Array.from(store.keys()),
+      clear: () => store.clear(),
+    };
+  },
+}));
+
+describe("python-bridge", () => {
+  it("spawnPythonBridge returns error for non-zero exit", async () => {
+    const { spawn } = await import("child_process");
+    const { spawnPythonBridge } = await import("../src/python-bridge.js");
+
+    (spawn as jest.Mock).mockImplementation(() => ({
+      stdout: { on: (_evt: string, cb: (d: Buffer) => void) => { cb(Buffer.from("")); } },
+      stderr: { on: (_evt: string, cb: (d: Buffer) => void) => { cb(Buffer.from("error msg")); } },
+      on: (event: string, cb: (code: number) => void) => {
+        if (event === "close") cb(1);
+      },
+    }));
+
+    const result = await spawnPythonBridge(
+      { pythonCommand: "test-cmd", repoPath: "/test", factoryPath: "/f", stateDir: ".s", eventsDir: ".e" } as any,
+      { action: "status" } as any,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("exited with code 1");
+  });
+
+  it("spawnPythonBridge parses valid JSON output", async () => {
+    const { spawn } = await import("child_process");
+    const { spawnPythonBridge } = await import("../src/python-bridge.js");
+
+    const validJson = JSON.stringify({
+      ok: true,
+      action: "run",
+      stage: "stage0_preflight",
+      status: "running",
+      issueNumber: 42,
+      statePath: "/tmp/state.json",
+    });
+
+    (spawn as jest.Mock).mockImplementation(() => ({
+      stdout: { on: (_evt: string, cb: (d: Buffer) => void) => { cb(Buffer.from(validJson)); } },
+      stderr: { on: (_evt: string, cb: (d: Buffer) => void) => {} },
+      on: (event: string, cb: (code: number) => void) => {
+        if (event === "close") cb(0);
+      },
+    }));
+
+    const result = await spawnPythonBridge(
+      { pythonCommand: "test-cmd", repoPath: "/test", factoryPath: "/f", stateDir: ".s", eventsDir: ".e" } as any,
+      { action: "run", issueNumber: 42 } as any,
+    );
+    expect(result.ok).toBe(true);
+    expect(result.stage).toBe("stage0_preflight");
+    expect(result.issueNumber).toBe(42);
+  });
+
+  it("spawnPythonBridge handles spawn error", async () => {
+    const { spawn } = await import("child_process");
+    const { spawnPythonBridge } = await import("../src/python-bridge.js");
+
+    (spawn as jest.Mock).mockImplementation(() => ({
+      stdout: { on: () => {} },
+      stderr: { on: () => {} },
+      on: (event: string, cb: (err: Error) => void) => {
+        if (event === "error") cb(new Error("spawn failed"));
+      },
+    }));
+
+    const result = await spawnPythonBridge(
+      { pythonCommand: "bad-cmd", repoPath: "/test", factoryPath: "/f", stateDir: ".s", eventsDir: ".e" } as any,
+      { action: "status" } as any,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Failed to spawn");
+  });
+});

--- a/tests/tool-schema.test.ts
+++ b/tests/tool-schema.test.ts
@@ -1,0 +1,73 @@
+import { jest, describe, it, expect } from "@jest/globals";
+
+const VALID_PARAMS = {
+  action: "run" as const,
+  issueNumber: 42,
+};
+
+const VALID_STATUS_PARAMS = {
+  action: "status" as const,
+};
+
+const mockApi = {
+  registerTool: jest.fn(),
+};
+
+const mockConfig = {
+  repoPath: "/test/repo",
+  factoryPath: "/test/factory",
+  pythonCommand: "railclaw-pipeline",
+  stateDir: ".pipeline-state",
+  eventsDir: ".pipeline-events",
+  agents: {
+    blueprint: { model: "test-model", timeout: 600 },
+    wrench: { model: "test-model", timeout: 600 },
+    scope: { model: "test-model", timeout: 600 },
+    beaker: { model: "test-model", timeout: 600 },
+    wrenchSr: { model: "test-model", timeout: 600 },
+  },
+  timing: { geminiPollInterval: 60, approvalTimeout: 86400, healthCheckTimeout: 30 },
+  pm2: { processName: "test", ecosystemPath: "test.cjs" },
+  escalation: { wrenchSrAfterRound: 3, chrisAfterRound: 5 },
+};
+
+jest.mock("child_process", () => ({
+  spawn: jest.fn(() => ({
+    stdout: { on: jest.fn() },
+    stderr: { on: jest.fn() },
+    on: jest.fn((event: string, cb: (code: number) => void) => {
+      if (event === "close") {
+        cb(0);
+      }
+    }),
+  })),
+}));
+
+describe("tool schema", () => {
+  it("registerPipelineTool registers with correct name", async () => {
+    const { registerPipelineTool } = await import("../src/tool.js");
+    registerPipelineTool(mockApi, mockConfig as any);
+    expect(mockApi.registerTool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "pipeline_run",
+      }),
+    );
+  });
+
+  it("tool has execute function", async () => {
+    const { registerPipelineTool } = await import("../src/tool.js");
+    registerPipelineTool(mockApi, mockConfig as any);
+    const tool = mockApi.registerTool.mock.calls[0][0];
+    expect(typeof tool.execute).toBe("function");
+  });
+
+  it("execute rejects run without issueNumber or milestone", async () => {
+    const { registerPipelineTool } = await import("../src/tool.js");
+    registerPipelineTool(mockApi, mockConfig as any);
+    const tool = mockApi.registerTool.mock.calls[0][0];
+    const result = await tool.execute("id-1", { action: "run" });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toContain("required");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022"],
+    "moduleResolution": "node",
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests", "python"]
+}


### PR DESCRIPTION
## Summary
Implements the full pipeline orchestrator as an OpenClaw plugin — a deterministic Python code orchestrator that replaces LLM-as-orchestrator for the RailClaw coding factory.

Closes #1

## What Changed
**Python core** (~3800 lines):
- Full pipeline state machine (PipelineStage + PipelineStatus enums, Pydantic models)
- Atomic JSON state persistence (tempfile + fsync + os.replace)
- Agent runner with async subprocess execution (shell=False, list args, kill-on-cancel)
- All 12 stages: Preflight → Blueprint → Wrench → PR → Audit → Review → Fix Loop → Gemini Cycle 2 → Approval → Merge → Deploy → QA → Hotfix → Lessons
- Cycle 2 Gemini review polling with `<details>` parsing, convergence detection, Wrench Sr fallback
- File-based approval protocol (approve/abort files)
- Milestone mode (multi-issue sequential execution)
- Sandboxed Jinja2 prompt templates (SSTI protection)
- Board JSON + Checkpoint MD management
- Buffered JSONL event emitter + Rich console output

**TypeScript plugin layer** (~200 lines):
- OpenClaw plugin via `definePluginEntry` + `registerTool`
- TypeBox parameter schema (run/status/resume/abort actions)
- Python CLI bridge with JSON stdout parsing
- Runtime store + lifecycle hooks

**Tests** (9 files, 612 lines):
- State models, persistence, agent runner, review parsing, approval gate, milestone, injection resistance, CLI, git sanitization

## Architecture Decision
Replaces LLM-as-orchestrator (known anti-pattern) with deterministic Python script. Every production coding system (Devin, Sweep, OpenHands, etc.) uses code as orchestrator. Full rationale in `factory/research-pipeline-reliability.md`.

## Testing
- 9 test files covering core logic
- Pre-commit hooks: tsc, prettier, eslint, pytest, ruff
- Pre-push hooks: full test suites + TODO scan
- Python 3.11+ ARM64 (Raspberry Pi)
