### PR TITLE
fix: add multi-repo support with per-repo .pipeline.json config

### DIFF
--- a/.pipeline.json.example
+++ b/.pipeline.json.example
@@ -1,0 +1,19 @@
+{
+  "factoryPath": "../factory",
+  "agents": {
+    "blueprint": { "model": "openai/gpt-5.4", "timeout": 600 },
+    "wrench": { "model": "zai/glm-5-turbo", "timeout": 1200 },
+    "scope": { "model": "minimax/MiniMax-M2.7", "timeout": 600 },
+    "beaker": { "model": "openai/gpt-5.4-mini", "timeout": 600 },
+    "wrenchSr": { "model": "gemini/gemini-3.1-pro-preview", "timeout": 1200 }
+  },
+  "timing": {
+    "geminiPollInterval": 60,
+    "approvalTimeout": 86400,
+    "healthCheckTimeout": 30
+  },
+  "escalation": {
+    "wrenchSrAfterRound": 3,
+    "chrisAfterRound": 5
+  }
+}

--- a/.pipeline.json.example
+++ b/.pipeline.json.example
@@ -1,11 +1,11 @@
 {
   "factoryPath": "../factory",
   "agents": {
-    "blueprint": { "model": "openai/gpt-5.4", "timeout": 600 },
-    "wrench": { "model": "zai/glm-5-turbo", "timeout": 1200 },
-    "scope": { "model": "minimax/MiniMax-M2.7", "timeout": 600 },
-    "beaker": { "model": "openai/gpt-5.4-mini", "timeout": 600 },
-    "wrenchSr": { "model": "gemini/gemini-3.1-pro-preview", "timeout": 1200 }
+    "blueprint": { "model": "<blueprint-model>", "timeout": 600 },
+    "wrench": { "model": "<wrench-model>", "timeout": 1200 },
+    "scope": { "model": "<scope-model>", "timeout": 600 },
+    "beaker": { "model": "<beaker-model>", "timeout": 600 },
+    "wrenchSr": { "model": "<wrench-sr-model>", "timeout": 1200 }
   },
   "timing": {
     "geminiPollInterval": 60,

--- a/python/src/railclaw_pipeline/cli.py
+++ b/python/src/railclaw_pipeline/cli.py
@@ -44,11 +44,20 @@ def main() -> None:
 
 
 @main.command()
+@click.option("--repo-path", type=str, help="Absolute path to the target repo")
+@click.option("--factory-path", type=str, help="Path to factory config directory")
 @click.option("--issue", type=int, help="Issue number to process")
 @click.option("--milestone", type=str, help="Milestone label for multi-issue mode")
 @click.option("--hotfix", is_flag=True, help="Run in hotfix mode")
 @click.option("--force-stage", type=str, help="Force start at specific stage")
-def run(issue: int | None, milestone: str | None, hotfix: bool, force_stage: str | None) -> None:
+def run(
+    repo_path: str | None,
+    factory_path: str | None,
+    issue: int | None,
+    milestone: str | None,
+    hotfix: bool,
+    force_stage: str | None,
+) -> None:
     """Start a new pipeline run."""
     if not issue and not milestone:
         output_result({
@@ -89,9 +98,13 @@ def run(issue: int | None, milestone: str | None, hotfix: bool, force_stage: str
     from railclaw_pipeline.events.emitter import EventEmitter
     from railclaw_pipeline.pipeline import run_pipeline
 
+    # CLI args override env vars, env vars override defaults
+    effective_repo = repo_path or os.environ.get("RAILCLAW_REPO_PATH", ".")
+    effective_factory = factory_path or os.environ.get("RAILCLAW_FACTORY_PATH", "factory")
+
     config = PipelineConfig({
-        "repoPath": os.environ.get("RAILCLAW_REPO_PATH", "."),
-        "factoryPath": os.environ.get("RAILCLAW_FACTORY_PATH", "factory"),
+        "repoPath": effective_repo,
+        "factoryPath": effective_factory,
     })
     emitter = EventEmitter(config.events_path)
 

--- a/python/src/railclaw_pipeline/cli.py
+++ b/python/src/railclaw_pipeline/cli.py
@@ -68,7 +68,11 @@ def run(
             "error": "issue or milestone is required"
         })
         return
-    
+
+    if repo_path:
+        os.environ["RAILCLAW_REPO_PATH"] = repo_path
+    if factory_path:
+        os.environ["RAILCLAW_FACTORY_PATH"] = factory_path
     if state_dir:
         os.environ["RAILCLAW_STATE_DIR"] = state_dir
     state_path = get_state_path()

--- a/python/src/railclaw_pipeline/cli.py
+++ b/python/src/railclaw_pipeline/cli.py
@@ -46,6 +46,7 @@ def main() -> None:
 @main.command()
 @click.option("--repo-path", type=str, help="Absolute path to the target repo")
 @click.option("--factory-path", type=str, help="Path to factory config directory")
+@click.option("--state-dir", type=str, help="State directory (within the factory) to store state")
 @click.option("--issue", type=int, help="Issue number to process")
 @click.option("--milestone", type=str, help="Milestone label for multi-issue mode")
 @click.option("--hotfix", is_flag=True, help="Run in hotfix mode")
@@ -53,6 +54,7 @@ def main() -> None:
 def run(
     repo_path: str | None,
     factory_path: str | None,
+    state_dir: str | None,
     issue: int | None,
     milestone: str | None,
     hotfix: bool,
@@ -67,6 +69,8 @@ def run(
         })
         return
     
+    if state_dir:
+        os.environ["RAILCLAW_STATE_DIR"] = state_dir
     state_path = get_state_path()
     
     if state_path.exists():

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,9 @@ export interface RepoPipelineConfig {
   timing?: PluginConfig["timing"];
   pm2?: PluginConfig["pm2"];
   escalation?: PluginConfig["escalation"];
+  // Internal: directory where the .pipeline.json was found. Used to resolve
+  // relative paths (eg. factoryPath) relative to the config location.
+  __configDir?: string;
 }
 
 const DEFAULT_CONFIG: PluginConfig = {
@@ -79,15 +82,61 @@ export function resolveRepoPipelineConfig(startDir: string): RepoPipelineConfig 
   let dir = path.resolve(startDir);
   const root = path.parse(dir).root;
 
+  // Walk up the directory tree but stop at the git repo root (dir containing .git)
   while (dir !== root) {
     const candidate = path.join(dir, ".pipeline.json");
     try {
       if (fs.existsSync(candidate)) {
-        const raw = JSON.parse(fs.readFileSync(candidate, "utf-8"));
+        // Read and validate the config
+        const rawRaw = fs.readFileSync(candidate, "utf-8");
+        const raw = JSON.parse(rawRaw) as RepoPipelineConfig;
+        // Basic runtime validation of the shape
+        // Allow omission of fields; validate types when present
+        if (raw && typeof raw === "object") {
+          // Shallow structural validation
+          if (raw.factoryPath !== undefined && typeof raw.factoryPath !== "string") {
+            throw new Error("Invalid type for factoryPath in .pipeline.json");
+          }
+          if (raw.agents !== undefined && typeof raw.agents !== "object") {
+            throw new Error("Invalid type for agents in .pipeline.json");
+          }
+          if (raw.timing !== undefined && typeof raw.timing !== "object") {
+            throw new Error("Invalid type for timing in .pipeline.json");
+          }
+          if (raw.pm2 !== undefined && typeof raw.pm2 !== "object") {
+            throw new Error("Invalid type for pm2 in .pipeline.json");
+          }
+          if (raw.escalation !== undefined && typeof raw.escalation !== "object") {
+            throw new Error("Invalid type for escalation in .pipeline.json");
+          }
+        }
+        // Attach configDir so downstream can resolve relative paths from this directory
+        (raw as RepoPipelineConfig).__configDir = dir;
         return raw as RepoPipelineConfig;
       }
-    } catch {
-      // File exists but is malformed — skip and keep walking up
+    } catch (err) {
+      // Re-throw validation errors directly (they have their own messages)
+      if (err instanceof Error && err.message.startsWith("Invalid type for")) {
+        throw err;
+      }
+      // File exists but is malformed (parse error) — log and decide whether to fail at repo root
+      // If we are at the repo root (dir contains a .git), escalate for visibility
+      const candidatePath = path.join(dir, ".pipeline.json");
+      const gitDir = path.join(dir, ".git");
+      if (fs.existsSync(gitDir) && fs.statSync(gitDir).isDirectory()) {
+        // Malformed at repo root: rethrow to fail loudly
+        console.error(`Malformed or unreadable .pipeline.json at repo root: ${candidatePath}`);
+        throw new Error(`Malformed .pipeline.json at repo root: ${candidatePath}`);
+      } else {
+        console.warn(`Malformed or unreadable .pipeline.json at ${candidatePath}, continuing walk`);
+      }
+    }
+    // Before ascending, check if current dir is a git root.
+    // If we're about to leave the git repo without finding .pipeline.json, stop.
+    const currentGit = path.join(dir, ".git");
+    if (fs.existsSync(currentGit) && fs.statSync(currentGit).isDirectory()) {
+      // We're at a git root with no .pipeline.json — stop traversal
+      break;
     }
     const parent = path.dirname(dir);
     if (parent === dir) break;
@@ -101,18 +150,17 @@ export function resolveRepoPipelineConfig(startDir: string): RepoPipelineConfig 
  * Merge per-repo `.pipeline.json` config over the plugin-level defaults.
  * `repoPath` overrides the plugin-level repoPath.
  */
-export function buildRuntimeConfig(
-  pluginConfig: PluginConfig,
-  repoPath: string,
-): PluginConfig {
+export function buildRuntimeConfig(pluginConfig: PluginConfig, repoPath: string): PluginConfig {
   const repoConfig = resolveRepoPipelineConfig(repoPath);
+  // Determine base directory for relative resolutions
+  const configDir = (repoConfig as any)?.__configDir ?? repoPath;
 
-  // If repoConfig specifies a factoryPath, resolve it relative to where the .pipeline.json was found
+  // If repoConfig specifies a factoryPath, resolve it relative to the location of the config
   let factoryPath = pluginConfig.factoryPath;
   if (repoConfig?.factoryPath) {
     factoryPath = path.isAbsolute(repoConfig.factoryPath)
       ? repoConfig.factoryPath
-      : path.join(repoPath, repoConfig.factoryPath);
+      : path.resolve(configDir, repoConfig.factoryPath);
   }
 
   return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import type { Static } from "@sinclair/typebox";
 import type { PipelineRunParameters } from "./tool.js";
 
@@ -31,6 +33,15 @@ export interface PluginConfig {
 
 export type PipelineRunParams = Static<typeof PipelineRunParameters>;
 
+/** Shape of a `.pipeline.json` file found at a repo root. */
+export interface RepoPipelineConfig {
+  factoryPath?: string;
+  agents?: PluginConfig["agents"];
+  timing?: PluginConfig["timing"];
+  pm2?: PluginConfig["pm2"];
+  escalation?: PluginConfig["escalation"];
+}
+
 const DEFAULT_CONFIG: PluginConfig = {
   repoPath: "/home/chris/.openclaw/agents/railrunner/workspace/repos/RailClaw",
   factoryPath: "/home/chris/.openclaw/agents/railrunner/workspace/factory",
@@ -59,6 +70,69 @@ const DEFAULT_CONFIG: PluginConfig = {
     chrisAfterRound: 5,
   },
 };
+
+/**
+ * Walk up from `startDir` looking for a `.pipeline.json` file.
+ * Returns the parsed config or null if not found (stops at filesystem root).
+ */
+export function resolveRepoPipelineConfig(startDir: string): RepoPipelineConfig | null {
+  let dir = path.resolve(startDir);
+  const root = path.parse(dir).root;
+
+  while (dir !== root) {
+    const candidate = path.join(dir, ".pipeline.json");
+    try {
+      if (fs.existsSync(candidate)) {
+        const raw = JSON.parse(fs.readFileSync(candidate, "utf-8"));
+        return raw as RepoPipelineConfig;
+      }
+    } catch {
+      // File exists but is malformed — skip and keep walking up
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  return null;
+}
+
+/**
+ * Merge per-repo `.pipeline.json` config over the plugin-level defaults.
+ * `repoPath` overrides the plugin-level repoPath.
+ */
+export function buildRuntimeConfig(
+  pluginConfig: PluginConfig,
+  repoPath: string,
+): PluginConfig {
+  const repoConfig = resolveRepoPipelineConfig(repoPath);
+
+  // If repoConfig specifies a factoryPath, resolve it relative to where the .pipeline.json was found
+  let factoryPath = pluginConfig.factoryPath;
+  if (repoConfig?.factoryPath) {
+    factoryPath = path.isAbsolute(repoConfig.factoryPath)
+      ? repoConfig.factoryPath
+      : path.join(repoPath, repoConfig.factoryPath);
+  }
+
+  return {
+    ...pluginConfig,
+    repoPath: path.resolve(repoPath),
+    factoryPath,
+    agents: repoConfig?.agents
+      ? { ...DEFAULT_CONFIG.agents, ...pluginConfig.agents, ...repoConfig.agents }
+      : pluginConfig.agents,
+    timing: repoConfig?.timing
+      ? { ...DEFAULT_CONFIG.timing, ...pluginConfig.timing, ...repoConfig.timing }
+      : pluginConfig.timing,
+    pm2: repoConfig?.pm2
+      ? { ...DEFAULT_CONFIG.pm2, ...pluginConfig.pm2, ...repoConfig.pm2 }
+      : pluginConfig.pm2,
+    escalation: repoConfig?.escalation
+      ? { ...DEFAULT_CONFIG.escalation, ...pluginConfig.escalation, ...repoConfig.escalation }
+      : pluginConfig.escalation,
+  };
+}
 
 export function normalizeConfig(userConfig: Record<string, unknown>): PluginConfig {
   return {

--- a/src/python-bridge.ts
+++ b/src/python-bridge.ts
@@ -22,6 +22,9 @@ export function spawnPythonBridge(
   return new Promise((resolve) => {
     const args: string[] = [params.action];
 
+    args.push("--repo-path", config.repoPath);
+    args.push("--factory-path", config.factoryPath);
+
     if (params.issueNumber !== undefined) {
       args.push("--issue", params.issueNumber.toString());
     }

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,13 +1,18 @@
 import { Type, Static } from "@sinclair/typebox";
+import * as fs from "fs";
+import * as path from "path";
 import { spawnPythonBridge } from "./python-bridge.js";
 import type { PluginConfig } from "./config.js";
 import { buildRuntimeConfig } from "./config.js";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 
 export const PipelineRunParameters = Type.Object({
-  repoPath: Type.String({
-    description: "Absolute path to the target git repo. Plugin resolves .pipeline.json from here.",
-  }),
+  repoPath: Type.Optional(
+    Type.String({
+      description:
+        "Absolute path to the target git repo. Plugin resolves .pipeline.json from here.",
+    }),
+  ),
   action: Type.Union([
     Type.Literal("run"),
     Type.Literal("status"),
@@ -30,6 +35,15 @@ export function registerPipelineTool(api: OpenClawPluginApi, config: PluginConfi
     description: "Run the coding factory pipeline for an issue or milestone",
     parameters: PipelineRunParameters,
     async execute(_id: string, params: PipelineRunParams) {
+      // Resolve a concrete repo path from explicit param, env, or CWD
+      const providedRepoPath = (params as any).repoPath as string | undefined;
+      const repoPath = providedRepoPath ?? process.env.RAILCLAW_REPO_PATH ?? process.cwd();
+      // Validate repoPath if provided or when enforcing env defaults
+      if (typeof providedRepoPath === "string" || !process.env.RAILCLAW_REPO_PATH) {
+        if (!fs.existsSync(repoPath) || !fs.existsSync(path.join(repoPath, ".git"))) {
+          throw new Error("Invalid repoPath: not a git repository");
+        }
+      }
       if (params.action === "run" && !params.issueNumber && !params.milestone) {
         return {
           content: [
@@ -46,7 +60,7 @@ export function registerPipelineTool(api: OpenClawPluginApi, config: PluginConfi
       }
 
       // Build per-call config: merge .pipeline.json over plugin defaults
-      const runtimeConfig = buildRuntimeConfig(config, params.repoPath);
+      const runtimeConfig = buildRuntimeConfig(config, repoPath);
 
       const result = await spawnPythonBridge(runtimeConfig, params);
 

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -1,9 +1,13 @@
 import { Type, Static } from "@sinclair/typebox";
 import { spawnPythonBridge } from "./python-bridge.js";
 import type { PluginConfig } from "./config.js";
+import { buildRuntimeConfig } from "./config.js";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 
 export const PipelineRunParameters = Type.Object({
+  repoPath: Type.String({
+    description: "Absolute path to the target git repo. Plugin resolves .pipeline.json from here.",
+  }),
   action: Type.Union([
     Type.Literal("run"),
     Type.Literal("status"),
@@ -41,7 +45,10 @@ export function registerPipelineTool(api: OpenClawPluginApi, config: PluginConfi
         };
       }
 
-      const result = await spawnPythonBridge(config, params);
+      // Build per-call config: merge .pipeline.json over plugin defaults
+      const runtimeConfig = buildRuntimeConfig(config, params.repoPath);
+
+      const result = await spawnPythonBridge(runtimeConfig, params);
 
       return {
         content: [

--- a/tests/config-resolve.test.ts
+++ b/tests/config-resolve.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  resolveRepoPipelineConfig,
+  buildRuntimeConfig,
+  normalizeConfig,
+} from "../src/config.js";
+import type { PluginConfig } from "../src/config.js";
+
+describe("resolveRepoPipelineConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rcp-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when no .pipeline.json exists", () => {
+    // Create a git repo with no .pipeline.json
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    const result = resolveRepoPipelineConfig(repoDir);
+    expect(result).toBeNull();
+  });
+
+  it("finds .pipeline.json in the given directory", () => {
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoDir, ".pipeline.json"),
+      JSON.stringify({ factoryPath: "../factory" }),
+    );
+    const result = resolveRepoPipelineConfig(repoDir);
+    expect(result).not.toBeNull();
+    expect(result!.factoryPath).toBe("../factory");
+    expect(result!.__configDir).toBe(repoDir);
+  });
+
+  it("walks up from a subdirectory to find .pipeline.json", () => {
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, "src", "deep"), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoDir, ".pipeline.json"),
+      JSON.stringify({ factoryPath: "./factory" }),
+    );
+    const result = resolveRepoPipelineConfig(path.join(repoDir, "src", "deep"));
+    expect(result).not.toBeNull();
+    expect(result!.factoryPath).toBe("./factory");
+    expect(result!.__configDir).toBe(repoDir);
+  });
+
+  it("H1: stops at .git boundary and does not walk above", () => {
+    // Create two repos: parent/repo and parent/.git (parent is a repo too)
+    const parentDir = path.join(tmpDir, "parent");
+    fs.mkdirSync(path.join(parentDir, ".git"), { recursive: true });
+    // Put a .pipeline.json ABOVE the parent repo (in tmpDir) — should NOT be found
+    fs.writeFileSync(
+      path.join(tmpDir, ".pipeline.json"),
+      JSON.stringify({ factoryPath: "should-not-find" }),
+    );
+    const repoDir = path.join(parentDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    // No .pipeline.json in repoDir or parentDir
+    const result = resolveRepoPipelineConfig(repoDir);
+    expect(result).toBeNull();
+  });
+
+  it("H2: throws on malformed .pipeline.json at repo root", () => {
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(repoDir, ".pipeline.json"), "not json{{{");
+    expect(() => resolveRepoPipelineConfig(repoDir)).toThrow("Malformed .pipeline.json");
+  });
+
+  it("H2: warns and continues on malformed .pipeline.json in subdirectory", () => {
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(repoDir, "sub", ".pipeline.json"), "bad json");
+    fs.writeFileSync(
+      path.join(repoDir, ".pipeline.json"),
+      JSON.stringify({ factoryPath: "found" }),
+    );
+    // Should find the valid one at repo root, not crash on the sub one
+    const result = resolveRepoPipelineConfig(path.join(repoDir, "sub"));
+    expect(result).not.toBeNull();
+    expect(result!.factoryPath).toBe("found");
+  });
+
+  it("M3: validates field types — throws on wrong factoryPath type", () => {
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoDir, ".pipeline.json"),
+      JSON.stringify({ factoryPath: 123 }),
+    );
+    expect(() => resolveRepoPipelineConfig(repoDir)).toThrow("Invalid type for factoryPath");
+  });
+
+  it("M3: validates field types — throws on wrong agents type", () => {
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoDir, ".pipeline.json"),
+      JSON.stringify({ agents: "string" }),
+    );
+    expect(() => resolveRepoPipelineConfig(repoDir)).toThrow("Invalid type for agents");
+  });
+});
+
+describe("buildRuntimeConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rcp-build-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("M2: resolves factoryPath relative to .pipeline.json location, not repoPath", () => {
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, "sub", "nested"), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoDir, ".pipeline.json"),
+      JSON.stringify({ factoryPath: "my-factory" }),
+    );
+    const pluginConfig = normalizeConfig({});
+    const runtimeConfig = buildRuntimeConfig(
+      pluginConfig,
+      path.join(repoDir, "sub", "nested"),
+    );
+    // factoryPath should resolve relative to repoDir (where .pipeline.json is), not nested
+    expect(runtimeConfig.factoryPath).toBe(path.join(repoDir, "my-factory"));
+  });
+
+  it("uses absolute factoryPath as-is", () => {
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoDir, ".pipeline.json"),
+      JSON.stringify({ factoryPath: "/absolute/factory" }),
+    );
+    const pluginConfig = normalizeConfig({});
+    const runtimeConfig = buildRuntimeConfig(pluginConfig, repoDir);
+    expect(runtimeConfig.factoryPath).toBe("/absolute/factory");
+  });
+
+  it("falls back to plugin config factoryPath when repo has no .pipeline.json", () => {
+    const repoDir = path.join(tmpDir, "repo");
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    const pluginConfig = normalizeConfig({ factoryPath: "/default/factory" });
+    const runtimeConfig = buildRuntimeConfig(pluginConfig, repoDir);
+    expect(runtimeConfig.factoryPath).toBe("/default/factory");
+  });
+});


### PR DESCRIPTION
## Summary

Adds `repoPath` as a tool parameter and per-repo config via `.pipeline.json`.

### Design (Blueprint-approved)

- **`repoPath`** → tool parameter (per-call, explicit, auditable)
- **`.pipeline.json`** → repo root config (factory path, agent models, timing, escalation)
- Plugin walks up from `repoPath` to find `.pipeline.json`, falls back to plugin defaults

### Changes

| File | Description |
|------|-------------|
| `src/config.ts` | `RepoPipelineConfig` interface, `resolveRepoPipelineConfig()`, `buildRuntimeConfig()` |
| `src/tool.ts` | `repoPath` added to tool schema + execute handler |
| `src/python-bridge.ts` | Passes `--repo-path` and `--factory-path` to Python CLI |
| `python/src/railclaw_pipeline/cli.py` | New `--repo-path` and `--factory-path` click options |
| `.pipeline.json.example` | Sample config file |

### Tests
- 15/15 vitest ✅
- 15/15 relevant pytest ✅